### PR TITLE
Check pixel size for Infinity or PIXEL units

### DIFF
--- a/omero_marshal/encode/encoders/pixels.py
+++ b/omero_marshal/encode/encoders/pixels.py
@@ -12,18 +12,24 @@
 from ... import SCHEMA_VERSION
 from .. import Encoder
 from omero.model import PixelsI
+from omero.model.enums import UnitsLength
 
 
 class Pixels201501Encoder(Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Pixels'
 
+    def set_pixel_size(self, v, key, value):
+        if (value.getValue() != float('inf') and value.getValue() is not None
+                and value.getUnit() != UnitsLength.PIXEL):
+            self.set_if_not_none(v, key, value)
+
     def encode(self, obj):
         v = super(Pixels201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'omero:methodology', obj.methodology)
-        self.set_if_not_none(v, 'PhysicalSizeX', obj.physicalSizeX)
-        self.set_if_not_none(v, 'PhysicalSizeY', obj.physicalSizeY)
-        self.set_if_not_none(v, 'PhysicalSizeZ', obj.physicalSizeZ)
+        self.set_pixel_size(v, 'PhysicalSizeX', obj.physicalSizeX)
+        self.set_pixel_size(v, 'PhysicalSizeY', obj.physicalSizeY)
+        self.set_pixel_size(v, 'PhysicalSizeZ', obj.physicalSizeZ)
         self.set_if_not_none(v, 'omero:sha1', obj.sha1)
         self.set_if_not_none(v, 'SignificantBits', obj.significantBits)
         self.set_if_not_none(v, 'SizeX', obj.sizeX)


### PR DESCRIPTION
See https://trello.com/c/X5egtRjc/3-iviewer-fails-to-load-images-with-pixel-size-nan-or-inf
JSON with ```Infinity``` values is invalid and is not handled by iviewer. We simply ignore these values now.

This is the equivalent of behaviour in Java: https://github.com/ome/omero-gateway-java/pull/14

To test: JSON data from an image with invalid pixel sizes should still be valid, and image viewable in iviewer.
 - NB: this PR is not deployed for testing. Need to test locally.
 - Image https://merge-ci.openmicroscopy.org/web/webclient/?show=image-19165 (user-3) has Infinity pixel sizeX.

This doesn't change anything for the old webgateway viewer. It will still work and show Infinity/null pixel sizes.

cc @dominikl 