### PR TITLE
Use major.minor for version detection

### DIFF
--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -45,7 +45,7 @@ def get_decoder(t):
         return None
 
 
-VERSION_REGEXP = re.compile(r'^(\d+\.\d+\.\d+)')
+VERSION_REGEXP = re.compile(r'^(\d+\.\d+)\.(a|b|dev)?\d+')
 
 
 def get_schema_version(version):

--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -45,7 +45,7 @@ def get_decoder(t):
         return None
 
 
-VERSION_REGEXP = re.compile(r'^(\d+\.\d+)\.(a|b|dev)?\d+')
+VERSION_REGEXP = re.compile(r'^(\d+\.\d+)\.(a|b|dev|rc)?\d+')
 
 
 def get_schema_version(version):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools.command.test import test as TestCommand
 import multiprocessing
 assert multiprocessing  # silence flake8
 
-VERSION = '0.6.1.dev1'
+VERSION = '0.6.1'
 
 
 def get_requirements(suffix=''):

--- a/tests/unit/test_schema_version.py
+++ b/tests/unit/test_schema_version.py
@@ -29,7 +29,12 @@ SFS = (SchemaFixture("5.2.0-ice35-b12", "2015-01"),
        SchemaFixture("5.3.0-ice36-b59", "2016-06"),
        SchemaFixture("5.3.1-ice36-SNAPSHOT", "2016-06"),
        SchemaFixture("5.4.0-ice36-SNAPSHOT", "2016-06"),
-       SchemaFixture("5.5.0-ice36-SNAPSHOT", "2016-06"))
+       SchemaFixture("5.5.0-ice36-SNAPSHOT", "2016-06"),
+       SchemaFixture("5.5.dev1", "2016-06"),
+       SchemaFixture("5.5.a2", "2016-06"),
+       SchemaFixture("5.5.b2", "2016-06"),
+       SchemaFixture("5.5.rc2", "2016-06"),
+       )
 
 
 @pytest.mark.parametrize("f", SFS, ids=[x.omero_version for x in SFS])


### PR DESCRIPTION
With the move of omero-web to PyPI, periodically development
versions prefixed with `dev`, `a`, `b`, or `rc` will be released.

See https://github.com/ome/openmicroscopy/pull/6100 for more information