### PR TITLE
Fix encode/decode imports in __init__.py

### DIFF
--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -14,7 +14,7 @@ import pkgutil
 import logging
 import re
 from omero_marshal.encode import encoders
-from omero_marshal.decode import decoders
+from .decode import decoders
 from distutils.version import StrictVersion
 from omero_version import omero_version
 

--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -13,8 +13,8 @@ import importlib
 import pkgutil
 import logging
 import re
-from encode import encoders
-from decode import decoders
+from omero_marshal.encode import encoders
+from omero_marshal.decode import decoders
 from distutils.version import StrictVersion
 from omero_version import omero_version
 

--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -13,7 +13,7 @@ import importlib
 import pkgutil
 import logging
 import re
-from omero_marshal.encode import encoders
+from .encode import encoders
 from .decode import decoders
 from distutils.version import StrictVersion
 from omero_version import omero_version


### PR DESCRIPTION
This is needed to fix my omero-web unit tests with py3.