### PR TITLE
import omero.all to avoid ordering errors

### DIFF
--- a/omero_marshal/decode/__init__.py
+++ b/omero_marshal/decode/__init__.py
@@ -9,6 +9,8 @@
 # jason@glencoesoftware.com.
 #
 
+# Needed to avoid import errors when this is the first import
+import omero.all  # noqa
 import omero.model
 import omero.model.enums
 

--- a/omero_marshal/encode/__init__.py
+++ b/omero_marshal/encode/__init__.py
@@ -9,6 +9,9 @@
 # jason@glencoesoftware.com.
 #
 
+
+# Needed to avoid import errors when this is the first import
+import omero.all  # noqa
 from omero import RType
 from omero_model_UnitBase import UnitBase
 from omero.rtypes import unwrap


### PR DESCRIPTION
This error may occur when omero_marshall is the first import
```
>>> import omero_marshal
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "omero_marshal/__init__.py", line 16, in <module>
    from .encode import encoders
  File "omero_marshal/encode/__init__.py", line 12, in <module>
    from omero import RType
ImportError: cannot import name RType
```