### PR TITLE
New JSON-LD context-based version

### DIFF
--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -38,6 +38,7 @@ def get_encoder(t):
 
 
 def get_decoder(t):
+    t = get_full_type(t)
     try:
         return DECODERS[t]
     except KeyError:
@@ -76,12 +77,20 @@ ROI_SCHEMA_URL = '%s/%s/%s' % (BASE_URL, ROI_NS, SCHEMA_VERSION)
 SA_SCHEMA_URL = '%s/%s/%s' % (BASE_URL, SA_NS, SCHEMA_VERSION)
 SPW_SCHEMA_URL = '%s/%s/%s' % (BASE_URL, SPW_NS, SCHEMA_VERSION)
 
+def get_full_type(t):
+    if t.startswith("http"):
+        return t
+    elif t.startswith("omero:"):
+        return '%s/OMERO/%s#%s' % (BASE_URL, SCHEMA_VERSION, t[6:])
+    else:
+        return '%s/OME/%s#%s' % (BASE_URL, SCHEMA_VERSION, t)
 
 class MarshallingCtx(object):
 
     def __init__(self, encoders, decoders):
         self.encoders = encoders
         self.decoders = decoders
+
 
     def get_encoder(self, t):
         try:
@@ -91,6 +100,7 @@ class MarshallingCtx(object):
             return None
 
     def get_decoder(self, t):
+        t = get_full_type(t)
         try:
             return self.decoders[t]
         except KeyError:

--- a/omero_marshal/decode/__init__.py
+++ b/omero_marshal/decode/__init__.py
@@ -30,6 +30,8 @@ class Decoder(object):
         if v is None:
             return None
         unit = v['@type'][v['@type'].rfind('#') + 1:]
+        if unit.startswith("omero:"):
+            unit = unit[6:]
         unit = getattr(omero.model, unit)
         return unit(
             float(v['Value']),

--- a/omero_marshal/decode/decoders/acquisitionmode.py
+++ b/omero_marshal/decode/decoders/acquisitionmode.py
@@ -15,7 +15,7 @@ from omero.model import AcquisitionModeI
 
 class AcquisitionModeDecoder(EnumDecoder):
 
-    TYPE = 'TBD#AcquisitionMode'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#AcquisitionMode'
 
     OMERO_CLASS = AcquisitionModeI
 

--- a/omero_marshal/decode/decoders/checksum_algorithm.py
+++ b/omero_marshal/decode/decoders/checksum_algorithm.py
@@ -15,7 +15,7 @@ from omero.model import ChecksumAlgorithmI
 
 class ChecksumAlgorithmDecoder(EnumDecoder):
 
-    TYPE = 'TBD#ChecksumAlgorithm'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#ChecksumAlgorithm'
 
     OMERO_CLASS = ChecksumAlgorithmI
 

--- a/omero_marshal/decode/decoders/contrastmethod.py
+++ b/omero_marshal/decode/decoders/contrastmethod.py
@@ -15,7 +15,7 @@ from omero.model import ContrastMethodI
 
 class ContrastMethodDecoder(EnumDecoder):
 
-    TYPE = 'TBD#ContrastMethod'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#ContrastMethod'
 
     OMERO_CLASS = ContrastMethodI
 

--- a/omero_marshal/decode/decoders/details.py
+++ b/omero_marshal/decode/decoders/details.py
@@ -15,7 +15,7 @@ from omero.model import DetailsI
 
 class DetailsDecoder(Decoder):
 
-    TYPE = 'TBD#Details'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#Details'
 
     OMERO_CLASS = DetailsI
 

--- a/omero_marshal/decode/decoders/dimensionorder.py
+++ b/omero_marshal/decode/decoders/dimensionorder.py
@@ -15,7 +15,7 @@ from omero.model import DimensionOrderI
 
 class DimensionOrderDecoder(EnumDecoder):
 
-    TYPE = 'TBD#DimensionOrder'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#DimensionOrder'
 
     OMERO_CLASS = DimensionOrderI
 

--- a/omero_marshal/decode/decoders/externalinfo.py
+++ b/omero_marshal/decode/decoders/externalinfo.py
@@ -15,7 +15,7 @@ from omero.model import ExternalInfoI
 
 class ExternalInfoDecoder(Decoder):
 
-    TYPE = 'TBD#ExternalInfo'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#ExternalInfo'
 
     OMERO_CLASS = ExternalInfoI
 

--- a/omero_marshal/decode/decoders/format.py
+++ b/omero_marshal/decode/decoders/format.py
@@ -15,7 +15,7 @@ from omero.model import FormatI
 
 class FormatDecoder(EnumDecoder):
 
-    TYPE = 'TBD#Format'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#Format'
 
     OMERO_CLASS = FormatI
 

--- a/omero_marshal/decode/decoders/illumination.py
+++ b/omero_marshal/decode/decoders/illumination.py
@@ -15,7 +15,7 @@ from omero.model import IlluminationI
 
 class IlluminationDecoder(EnumDecoder):
 
-    TYPE = 'TBD#Illumination'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#IlluminationType'
 
     OMERO_CLASS = IlluminationI
 

--- a/omero_marshal/decode/decoders/original_file.py
+++ b/omero_marshal/decode/decoders/original_file.py
@@ -15,7 +15,7 @@ from omero.model import OriginalFileI
 
 class OriginalFileDecoder(Decoder):
 
-    TYPE = 'TBD#OriginalFile'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#OriginalFile'
 
     OMERO_CLASS = OriginalFileI
 

--- a/omero_marshal/decode/decoders/permissions.py
+++ b/omero_marshal/decode/decoders/permissions.py
@@ -15,7 +15,7 @@ from omero.model import PermissionsI
 
 class PermissionsDecoder(Decoder):
 
-    TYPE = 'TBD#Permissions'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#Permissions'
 
     OMERO_CLASS = PermissionsI
 

--- a/omero_marshal/decode/decoders/photometricinterpretation.py
+++ b/omero_marshal/decode/decoders/photometricinterpretation.py
@@ -15,7 +15,7 @@ from omero.model import PhotometricInterpretationI
 
 class PhotometricInterpretationDecoder(EnumDecoder):
 
-    TYPE = 'TBD#PhotometricInterpretation'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#PhotometricInterpretation'
 
     OMERO_CLASS = PhotometricInterpretationI
 

--- a/omero_marshal/decode/decoders/pixelstype.py
+++ b/omero_marshal/decode/decoders/pixelstype.py
@@ -15,7 +15,7 @@ from omero.model import PixelsTypeI
 
 class PixelsTypeDecoder(EnumDecoder):
 
-    TYPE = 'TBD#PixelsType'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#PixelType'
 
     OMERO_CLASS = PixelsTypeI
 

--- a/omero_marshal/encode/__init__.py
+++ b/omero_marshal/encode/__init__.py
@@ -9,6 +9,8 @@
 # jason@glencoesoftware.com.
 #
 
+OME_CONTEXT = "https://gist.githubusercontent.com/stefanches7/5b3402331d901bb3c3384bac047c4ac2/raw/cd45da585bfa630a56ef55670d2b5da2be50ff76/context.ld.json"
+OMERO_CONTEXT = "TODO"
 
 # Needed to avoid import errors when this is the first import
 import omero.all  # noqa
@@ -43,7 +45,13 @@ class Encoder(object):
         }
 
     def encode(self, obj):
-        v = {'@type': self.TYPE}
+        v = {
+            '@context': {
+                "ome": OME_CONTEXT,
+                "omero": OMERO_CONTEXT,
+            },
+            '@type': self.TYPE
+        }
         if hasattr(obj, 'id'):
             obj_id = unwrap(obj.id)
             if obj_id is not None:

--- a/omero_marshal/encode/__init__.py
+++ b/omero_marshal/encode/__init__.py
@@ -44,21 +44,22 @@ class Encoder(object):
             'Value': value.getValue()
         }
 
-    def encode(self, obj):
-        v = {
-            '@context': {
+    def encode(self, obj, include_context=None):
+
+        v = {'@type': self.TYPE}
+        if include_context is None or include_context:
+            v['@context'] = {
                 "ome": OME_CONTEXT,
                 "omero": OMERO_CONTEXT,
-            },
-            '@type': self.TYPE
-        }
+            }
+
         if hasattr(obj, 'id'):
             obj_id = unwrap(obj.id)
             if obj_id is not None:
                 v['@id'] = obj_id
         if hasattr(obj, 'details') and obj.details is not None:
             encoder = self.ctx.get_encoder(obj.details.__class__)
-            v['omero:details'] = encoder.encode(obj.details)
+            v['omero:details'] = encoder.encode(obj.details, False)
 
         return v
 

--- a/omero_marshal/encode/__init__.py
+++ b/omero_marshal/encode/__init__.py
@@ -9,8 +9,8 @@
 # jason@glencoesoftware.com.
 #
 
-OME_CONTEXT = "https://gist.githubusercontent.com/stefanches7/5b3402331d901bb3c3384bac047c4ac2/raw/cd45da585bfa630a56ef55670d2b5da2be50ff76/context.ld.json"
-OMERO_CONTEXT = "TODO"
+BASE_CONTEXT = "http://www.openmicroscopy.org/Schemas/OME/2016-06#"
+OMERO_CONTEXT = "http://www.openmicroscopy.org/Schemas/OMERO/2016-06#"
 
 # Needed to avoid import errors when this is the first import
 import omero.all  # noqa
@@ -46,10 +46,16 @@ class Encoder(object):
 
     def encode(self, obj, include_context=None):
 
-        v = {'@type': self.TYPE}
+        if self.TYPE.startswith(BASE_CONTEXT):
+            v = {'@type': self.TYPE.split('#')[-1]}
+        elif self.TYPE.startswith(OMERO_CONTEXT):
+            v = {'@type': "omero:" + self.TYPE.split('#')[-1]}
+        else:
+            raise Exception("unknown prefix: %s" % self.TYPE)
+
         if include_context is None or include_context:
             v['@context'] = {
-                "ome": OME_CONTEXT,
+                "@base": BASE_CONTEXT,
                 "omero": OMERO_CONTEXT,
             }
 

--- a/omero_marshal/encode/__init__.py
+++ b/omero_marshal/encode/__init__.py
@@ -37,12 +37,16 @@ class Encoder(object):
             v[key] = value
 
     def encode_unit(self, v, key, value):
-        v[key] = {
-            '@type': 'TBD#%s' % value.__class__.__name__,
-            'Unit': value.getUnit().name,
-            'Symbol': value.getSymbol(),
-            'Value': value.getValue()
-        }
+        k = value.__class__.__name__
+        if k in ("LengthI", "TimeI"):
+            v[key] = {
+                '@type': 'omero:%s' % k,
+                'Unit': value.getUnit().name,
+                'Symbol': value.getSymbol(),
+                'Value': value.getValue()
+            }
+        else:
+            raise Exception("unhandled unit: %s" % k)
 
     def encode(self, obj, include_context=None):
 

--- a/omero_marshal/encode/encoders/acquisitionmode.py
+++ b/omero_marshal/encode/encoders/acquisitionmode.py
@@ -15,7 +15,7 @@ from omero.model import AcquisitionModeI
 
 class AcquisitionModeEncoder(EnumEncoder):
 
-    TYPE = 'TBD#AcquisitionMode'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#AcquisitionMode'
 
 
 encoder = (AcquisitionModeI, AcquisitionModeEncoder)

--- a/omero_marshal/encode/encoders/affinetransform.py
+++ b/omero_marshal/encode/encoders/affinetransform.py
@@ -24,8 +24,8 @@ class AffineTransform201501Encoder(Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#AffineTransform'
 
-    def encode(self, obj):
-        v = super(AffineTransform201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(AffineTransform201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'A00', obj.getA00())
         self.set_if_not_none(v, 'A10', obj.getA10())
         self.set_if_not_none(v, 'A01', obj.getA01())

--- a/omero_marshal/encode/encoders/annotation.py
+++ b/omero_marshal/encode/encoders/annotation.py
@@ -47,8 +47,8 @@ class Annotation201501Encoder(Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#Annotation'
 
-    def encode(self, obj):
-        v = super(Annotation201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Annotation201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Description', obj.description)
         self.set_if_not_none(v, 'Namespace', obj.ns)
         return v
@@ -63,15 +63,15 @@ class Annotatable201501Encoder(Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#AnnotationRef'
 
-    def encode(self, obj):
-        v = super(Annotatable201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Annotatable201501Encoder, self).encode(obj, include_context)
         if obj.isAnnotationLinksLoaded() and obj.sizeOfAnnotationLinks() > 0:
             annotations = list()
             for annotation_link in obj.copyAnnotationLinks():
                 annotation = annotation_link.child
                 annotation_encoder = self.ctx.get_encoder(annotation.__class__)
                 annotations.append(
-                    annotation_encoder.encode(annotation)
+                    annotation_encoder.encode(annotation, False)
                 )
             v['Annotations'] = annotations
         return v

--- a/omero_marshal/encode/encoders/boolean_annotation.py
+++ b/omero_marshal/encode/encoders/boolean_annotation.py
@@ -19,8 +19,8 @@ class BooleanAnnotation201501Encoder(AnnotationEncoder):
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#BooleanAnnotation'
 
-    def encode(self, obj):
-        v = super(BooleanAnnotation201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(BooleanAnnotation201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Value', obj.boolValue)
         return v
 

--- a/omero_marshal/encode/encoders/channel.py
+++ b/omero_marshal/encode/encoders/channel.py
@@ -18,8 +18,8 @@ class Channel201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Channel'
 
-    def encode(self, obj):
-        v = super(Channel201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Channel201501Encoder, self).encode(obj, include_context)
         color = self.rgba_to_int(obj.red, obj.green, obj.blue, obj.alpha)
         self.set_if_not_none(v, 'Color', color)
         self.set_if_not_none(v, 'omero:lookupTable', obj.lookupTable)
@@ -49,19 +49,19 @@ class Channel201501Encoder(AnnotatableEncoder):
                 contrast_method_encoder = \
                     self.ctx.get_encoder(contrast_method.__class__)
                 v['ContrastMethod'] = \
-                    contrast_method_encoder.encode(contrast_method)
+                    contrast_method_encoder.encode(contrast_method, False)
             illumination = logical_channel.illumination
             if illumination is not None and illumination.isLoaded():
                 illumination_encoder = \
                     self.ctx.get_encoder(illumination.__class__)
                 v['Illumination'] = \
-                    illumination_encoder.encode(illumination)
+                    illumination_encoder.encode(illumination, False)
             acquisition_mode = logical_channel.mode
             if acquisition_mode is not None and acquisition_mode.isLoaded():
                 acquisition_mode_encoder = \
                     self.ctx.get_encoder(acquisition_mode.__class__)
                 v['AcquisitionMode'] = \
-                    acquisition_mode_encoder.encode(acquisition_mode)
+                    acquisition_mode_encoder.encode(acquisition_mode, False)
             photometric_interpretation = \
                 logical_channel.photometricInterpretation
             if photometric_interpretation is not None \
@@ -70,7 +70,7 @@ class Channel201501Encoder(AnnotatableEncoder):
                     self.ctx.get_encoder(photometric_interpretation.__class__)
                 v['omero:photometricInterpretation'] = \
                     photometric_interpretation_encoder.encode(
-                        photometric_interpretation
+                        photometric_interpretation, False
                     )
         return v
 

--- a/omero_marshal/encode/encoders/checksum_algorithm.py
+++ b/omero_marshal/encode/encoders/checksum_algorithm.py
@@ -15,7 +15,7 @@ from omero.model import ChecksumAlgorithmI
 
 class ChecksumAlgorithmEncoder(EnumEncoder):
 
-    TYPE = 'TBD#ChecksumAlgorithm'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#ChecksumAlgorithm'
 
 
 encoder = (ChecksumAlgorithmI, ChecksumAlgorithmEncoder)

--- a/omero_marshal/encode/encoders/comment_annotation.py
+++ b/omero_marshal/encode/encoders/comment_annotation.py
@@ -19,8 +19,8 @@ class CommentAnnotation201501Encoder(TextAnnotationEncoder):
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#CommentAnnotation'
 
-    def encode(self, obj):
-        v = super(CommentAnnotation201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(CommentAnnotation201501Encoder, self).encode(obj, include_context)
         return v
 
 

--- a/omero_marshal/encode/encoders/contrastmethod.py
+++ b/omero_marshal/encode/encoders/contrastmethod.py
@@ -15,7 +15,7 @@ from omero.model import ContrastMethodI
 
 class ContrastMethodEncoder(EnumEncoder):
 
-    TYPE = 'TBD#ContrastMethod'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#ContrastMethod'
 
 
 encoder = (ContrastMethodI, ContrastMethodEncoder)

--- a/omero_marshal/encode/encoders/dataset.py
+++ b/omero_marshal/encode/encoders/dataset.py
@@ -18,8 +18,8 @@ class Dataset201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Dataset'
 
-    def encode(self, obj):
-        v = super(Dataset201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Dataset201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Name', obj.name)
         self.set_if_not_none(v, 'Description', obj.description)
         if obj.isImageLinksLoaded() and obj.sizeOfImageLinks() > 0:
@@ -28,7 +28,7 @@ class Dataset201501Encoder(AnnotatableEncoder):
                 image = image_link.child
                 image_encoder = self.ctx.get_encoder(image.__class__)
                 images.append(
-                    image_encoder.encode(image)
+                    image_encoder.encode(image, False)
                 )
             v['Images'] = images
         return v

--- a/omero_marshal/encode/encoders/details.py
+++ b/omero_marshal/encode/encoders/details.py
@@ -15,7 +15,7 @@ from omero.model import DetailsI
 
 class DetailsEncoder(Encoder):
 
-    TYPE = 'TBD#Details'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#Details'
 
     def encode(self, obj, include_context=None):
         # Never include contexts on these objects

--- a/omero_marshal/encode/encoders/details.py
+++ b/omero_marshal/encode/encoders/details.py
@@ -17,20 +17,20 @@ class DetailsEncoder(Encoder):
 
     TYPE = 'TBD#Details'
 
-    def encode(self, obj):
-        v = super(DetailsEncoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(DetailsEncoder, self).encode(obj, include_context)
         if obj.owner is not None:
             encoder = self.ctx.get_encoder(obj.owner.__class__)
-            v['owner'] = encoder.encode(obj.owner)
+            v['owner'] = encoder.encode(obj.owner, False)
         if obj.group is not None:
             encoder = self.ctx.get_encoder(obj.group.__class__)
-            v['group'] = encoder.encode(obj.group)
+            v['group'] = encoder.encode(obj.group, False)
         if obj.permissions is not None:
             encoder = self.ctx.get_encoder(obj.permissions.__class__)
-            v['permissions'] = encoder.encode(obj.permissions)
+            v['permissions'] = encoder.encode(obj.permissions, False)
         if obj.externalInfo is not None:
             encoder = self.ctx.get_encoder(obj.externalInfo.__class__)
-            v['externalInfo'] = encoder.encode(obj.externalInfo)
+            v['externalInfo'] = encoder.encode(obj.externalInfo, False)
         return v
 
 

--- a/omero_marshal/encode/encoders/details.py
+++ b/omero_marshal/encode/encoders/details.py
@@ -18,7 +18,8 @@ class DetailsEncoder(Encoder):
     TYPE = 'TBD#Details'
 
     def encode(self, obj, include_context=None):
-        v = super(DetailsEncoder, self).encode(obj, include_context)
+        # Never include contexts on these objects
+        v = super(DetailsEncoder, self).encode(obj, False)
         if obj.owner is not None:
             encoder = self.ctx.get_encoder(obj.owner.__class__)
             v['owner'] = encoder.encode(obj.owner, False)

--- a/omero_marshal/encode/encoders/dimensionorder.py
+++ b/omero_marshal/encode/encoders/dimensionorder.py
@@ -15,7 +15,7 @@ from omero.model import DimensionOrderI
 
 class DimensionOrderEncoder(EnumEncoder):
 
-    TYPE = 'TBD#DimensionOrder'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#DimensionOrder'
 
 
 encoder = (DimensionOrderI, DimensionOrderEncoder)

--- a/omero_marshal/encode/encoders/double_annotation.py
+++ b/omero_marshal/encode/encoders/double_annotation.py
@@ -19,8 +19,8 @@ class DoubleAnnotation201501Encoder(AnnotationEncoder):
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#DoubleAnnotation'
 
-    def encode(self, obj):
-        v = super(DoubleAnnotation201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(DoubleAnnotation201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Value', obj.doubleValue)
         return v
 

--- a/omero_marshal/encode/encoders/ellipse.py
+++ b/omero_marshal/encode/encoders/ellipse.py
@@ -22,8 +22,8 @@ class Ellipse201501Encoder(ShapeEncoder):
     RADIUSX_PROPERTY_NAME = 'rx'
     RADIUSY_PROPERTY_NAME = 'ry'
 
-    def encode(self, obj):
-        v = super(Ellipse201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Ellipse201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'X', getattr(obj, self.X_PROPERTY_NAME))
         self.set_if_not_none(v, 'Y', getattr(obj, self.Y_PROPERTY_NAME))
         self.set_if_not_none(

--- a/omero_marshal/encode/encoders/enum.py
+++ b/omero_marshal/encode/encoders/enum.py
@@ -17,7 +17,7 @@ class EnumEncoder(Encoder):
     def __init__(self, ctx):
         super(EnumEncoder, self).__init__(ctx)
 
-    def encode(self, obj):
-        v = super(EnumEncoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(EnumEncoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'value', obj.value)
         return v

--- a/omero_marshal/encode/encoders/experimenter.py
+++ b/omero_marshal/encode/encoders/experimenter.py
@@ -18,8 +18,8 @@ class Experimenter201501Encoder(Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Experimenter'
 
-    def encode(self, obj):
-        v = super(Experimenter201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Experimenter201501Encoder, self).encode(obj, include_context)
         if not obj.isLoaded():
             return v
         self.set_if_not_none(v, 'FirstName', obj.firstName)

--- a/omero_marshal/encode/encoders/experimentergroup.py
+++ b/omero_marshal/encode/encoders/experimentergroup.py
@@ -19,8 +19,8 @@ class ExperimenterGroup201501Encoder(Encoder):
     TYPE = \
         'http://www.openmicroscopy.org/Schemas/OME/2015-01#ExperimenterGroup'
 
-    def encode(self, obj):
-        v = super(ExperimenterGroup201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(ExperimenterGroup201501Encoder, self).encode(obj, include_context)
         if not obj.isLoaded():
             return v
         self.set_if_not_none(v, 'Description', obj.description)

--- a/omero_marshal/encode/encoders/externalinfo.py
+++ b/omero_marshal/encode/encoders/externalinfo.py
@@ -18,7 +18,8 @@ class ExternalInfoEncoder(Encoder):
     TYPE = 'TBD#ExternalInfo'
 
     def encode(self, obj, include_context=None):
-        v = super(ExternalInfoEncoder, self).encode(obj, include_context)
+        # Never include contexts for these objects
+        v = super(ExternalInfoEncoder, self).encode(obj, False)
         if not obj.isLoaded():
             return v
         self.set_if_not_none(v, 'EntityId', obj.entityId)

--- a/omero_marshal/encode/encoders/externalinfo.py
+++ b/omero_marshal/encode/encoders/externalinfo.py
@@ -15,7 +15,7 @@ from omero.model import ExternalInfoI
 
 class ExternalInfoEncoder(Encoder):
 
-    TYPE = 'TBD#ExternalInfo'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#ExternalInfo'
 
     def encode(self, obj, include_context=None):
         # Never include contexts for these objects

--- a/omero_marshal/encode/encoders/externalinfo.py
+++ b/omero_marshal/encode/encoders/externalinfo.py
@@ -17,8 +17,8 @@ class ExternalInfoEncoder(Encoder):
 
     TYPE = 'TBD#ExternalInfo'
 
-    def encode(self, obj):
-        v = super(ExternalInfoEncoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(ExternalInfoEncoder, self).encode(obj, include_context)
         if not obj.isLoaded():
             return v
         self.set_if_not_none(v, 'EntityId', obj.entityId)

--- a/omero_marshal/encode/encoders/file_annotation.py
+++ b/omero_marshal/encode/encoders/file_annotation.py
@@ -19,12 +19,12 @@ class FileAnnotation201501Encoder(AnnotationEncoder):
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#FileAnnotation'
 
-    def encode(self, obj):
-        v = super(FileAnnotation201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(FileAnnotation201501Encoder, self).encode(obj, include_context)
         if obj.file is not None and obj.file.isLoaded():
             original_file_encoder = \
                     self.ctx.get_encoder(obj.file.__class__)
-            v['File'] = original_file_encoder.encode(obj.file)
+            v['File'] = original_file_encoder.encode(obj.file, False)
         return v
 
 

--- a/omero_marshal/encode/encoders/format.py
+++ b/omero_marshal/encode/encoders/format.py
@@ -15,7 +15,7 @@ from omero.model import FormatI
 
 class FormatEncoder(EnumEncoder):
 
-    TYPE = 'TBD#Format'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#Format'
 
 
 encoder = (FormatI, FormatEncoder)

--- a/omero_marshal/encode/encoders/illumination.py
+++ b/omero_marshal/encode/encoders/illumination.py
@@ -15,7 +15,7 @@ from omero.model import IlluminationI
 
 class IlluminationEncoder(EnumEncoder):
 
-    TYPE = 'TBD#Illumination'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#IlluminationType'
 
 
 encoder = (IlluminationI, IlluminationEncoder)

--- a/omero_marshal/encode/encoders/image.py
+++ b/omero_marshal/encode/encoders/image.py
@@ -18,8 +18,8 @@ class Image201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Image'
 
-    def encode(self, obj):
-        v = super(Image201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Image201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'AcquisitionDate', obj.acquisitionDate)
         self.set_if_not_none(v, 'omero:archived', obj.archived)
         self.set_if_not_none(v, 'Description', obj.description)
@@ -30,12 +30,12 @@ class Image201501Encoder(AnnotatableEncoder):
         if _format is not None and _format.isLoaded():
             format_encoder = self.ctx.get_encoder(obj.format.__class__)
             self.set_if_not_none(
-                v, 'omero:format', format_encoder.encode(obj.format)
+                v, 'omero:format', format_encoder.encode(obj.format, False)
             )
         if obj.isPixelsLoaded() and obj.sizeOfPixels() > 0:
             pixels = obj.getPrimaryPixels()
             pixels_encoder = self.ctx.get_encoder(pixels.__class__)
-            v['Pixels'] = pixels_encoder.encode(pixels)
+            v['Pixels'] = pixels_encoder.encode(pixels, False)
         return v
 
 

--- a/omero_marshal/encode/encoders/label.py
+++ b/omero_marshal/encode/encoders/label.py
@@ -18,8 +18,8 @@ class Label201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Label'
 
-    def encode(self, obj):
-        v = super(Label201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Label201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'X', obj.x)
         self.set_if_not_none(v, 'Y', obj.y)
         return v

--- a/omero_marshal/encode/encoders/line.py
+++ b/omero_marshal/encode/encoders/line.py
@@ -18,8 +18,8 @@ class Line201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Line'
 
-    def encode(self, obj):
-        v = super(Line201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Line201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'X1', obj.x1)
         self.set_if_not_none(v, 'Y1', obj.y1)
         self.set_if_not_none(v, 'X2', obj.x2)
@@ -31,8 +31,8 @@ class Line201606Encoder(Line201501Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Line'
 
-    def encode(self, obj):
-        v = super(Line201606Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Line201606Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'MarkerStart', obj.markerStart)
         self.set_if_not_none(v, 'MarkerEnd', obj.markerEnd)
         return v

--- a/omero_marshal/encode/encoders/long_annotation.py
+++ b/omero_marshal/encode/encoders/long_annotation.py
@@ -19,8 +19,8 @@ class LongAnnotation201501Encoder(AnnotationEncoder):
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#LongAnnotation'
 
-    def encode(self, obj):
-        v = super(LongAnnotation201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(LongAnnotation201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Value', obj.longValue)
         return v
 

--- a/omero_marshal/encode/encoders/map_annotation.py
+++ b/omero_marshal/encode/encoders/map_annotation.py
@@ -19,8 +19,8 @@ class MapAnnotation201501Encoder(AnnotationEncoder):
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#MapAnnotation'
 
-    def encode(self, obj):
-        v = super(MapAnnotation201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(MapAnnotation201501Encoder, self).encode(obj, include_context)
         if obj.mapValue is None:
             return None
         self.set_if_not_none(

--- a/omero_marshal/encode/encoders/mask.py
+++ b/omero_marshal/encode/encoders/mask.py
@@ -18,8 +18,8 @@ class Mask201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Mask'
 
-    def encode(self, obj):
-        v = super(Mask201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Mask201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'X', obj.x)
         self.set_if_not_none(v, 'Y', obj.y)
         self.set_if_not_none(v, 'Width', obj.width)

--- a/omero_marshal/encode/encoders/original_file.py
+++ b/omero_marshal/encode/encoders/original_file.py
@@ -17,8 +17,8 @@ class OriginalFileEncoder(Encoder):
 
     TYPE = 'TBD#OriginalFile'
 
-    def encode(self, obj):
-        v = super(OriginalFileEncoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(OriginalFileEncoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'path', obj.path)
         self.set_if_not_none(v, 'size', obj.size)
         self.set_if_not_none(v, 'atime', obj.atime)
@@ -31,7 +31,7 @@ class OriginalFileEncoder(Encoder):
             checksum_algorithm_encoder = \
                 self.ctx.get_encoder(obj.hasher.__class__)
             v['hasher'] = \
-                checksum_algorithm_encoder.encode(obj.hasher)
+                checksum_algorithm_encoder.encode(obj.hasher, False)
         return v
 
 

--- a/omero_marshal/encode/encoders/original_file.py
+++ b/omero_marshal/encode/encoders/original_file.py
@@ -15,7 +15,7 @@ from omero.model import OriginalFileI
 
 class OriginalFileEncoder(Encoder):
 
-    TYPE = 'TBD#OriginalFile'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#OriginalFile'
 
     def encode(self, obj, include_context=None):
         v = super(OriginalFileEncoder, self).encode(obj, include_context)

--- a/omero_marshal/encode/encoders/permissions.py
+++ b/omero_marshal/encode/encoders/permissions.py
@@ -15,7 +15,7 @@ from omero.model import PermissionsI
 
 class PermissionsEncoder(Encoder):
 
-    TYPE = 'TBD#Permissions'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#Permissions'
 
     def encode(self, obj, include_context=None):
         # Never include contexts on these objects

--- a/omero_marshal/encode/encoders/permissions.py
+++ b/omero_marshal/encode/encoders/permissions.py
@@ -18,7 +18,8 @@ class PermissionsEncoder(Encoder):
     TYPE = 'TBD#Permissions'
 
     def encode(self, obj, include_context=None):
-        v = super(PermissionsEncoder, self).encode(obj, include_context)
+        # Never include contexts on these objects
+        v = super(PermissionsEncoder, self).encode(obj, False)
         v['perm'] = str(obj)
         v['canAnnotate'] = obj.canAnnotate()
         v['canDelete'] = obj.canDelete()

--- a/omero_marshal/encode/encoders/permissions.py
+++ b/omero_marshal/encode/encoders/permissions.py
@@ -17,8 +17,8 @@ class PermissionsEncoder(Encoder):
 
     TYPE = 'TBD#Permissions'
 
-    def encode(self, obj):
-        v = super(PermissionsEncoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(PermissionsEncoder, self).encode(obj, include_context)
         v['perm'] = str(obj)
         v['canAnnotate'] = obj.canAnnotate()
         v['canDelete'] = obj.canDelete()

--- a/omero_marshal/encode/encoders/photometricinterpretation.py
+++ b/omero_marshal/encode/encoders/photometricinterpretation.py
@@ -15,7 +15,7 @@ from omero.model import PhotometricInterpretationI
 
 class PhotometricInterpretationEncoder(EnumEncoder):
 
-    TYPE = 'TBD#PhotometricInterpretation'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#PhotometricInterpretation'
 
 
 encoder = (PhotometricInterpretationI, PhotometricInterpretationEncoder)

--- a/omero_marshal/encode/encoders/pixels.py
+++ b/omero_marshal/encode/encoders/pixels.py
@@ -18,8 +18,8 @@ class Pixels201501Encoder(Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Pixels'
 
-    def encode(self, obj):
-        v = super(Pixels201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Pixels201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'omero:methodology', obj.methodology)
         self.set_if_not_none(v, 'PhysicalSizeX', obj.physicalSizeX)
         self.set_if_not_none(v, 'PhysicalSizeY', obj.physicalSizeY)
@@ -39,17 +39,17 @@ class Pixels201501Encoder(Encoder):
             dimension_order_encoder = \
                 self.ctx.get_encoder(dimension_order.__class__)
             v['DimensionOrder'] = \
-                dimension_order_encoder.encode(dimension_order)
+                dimension_order_encoder.encode(dimension_order, False)
         pixels_type = obj.pixelsType
         if pixels_type is not None and pixels_type.isLoaded():
             pixels_type_encoder = \
                 self.ctx.get_encoder(pixels_type.__class__)
-            v['Type'] = pixels_type_encoder.encode(pixels_type)
+            v['Type'] = pixels_type_encoder.encode(pixels_type, False)
         if obj.isChannelsLoaded() and obj.sizeOfChannels() > 0:
             channels = list()
             for channel in obj.copyChannels():
                 channel_encoder = self.ctx.get_encoder(channel.__class__)
-                channels.append(channel_encoder.encode(channel))
+                channels.append(channel_encoder.encode(channel, False))
             v['Channels'] = channels
         return v
 

--- a/omero_marshal/encode/encoders/pixelstype.py
+++ b/omero_marshal/encode/encoders/pixelstype.py
@@ -15,7 +15,7 @@ from omero.model import PixelsTypeI
 
 class PixelsTypeEncoder(EnumEncoder):
 
-    TYPE = 'TBD#PixelsType'
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#PixelType'
 
 
 encoder = (PixelsTypeI, PixelsTypeEncoder)

--- a/omero_marshal/encode/encoders/plate.py
+++ b/omero_marshal/encode/encoders/plate.py
@@ -18,8 +18,8 @@ class Plate201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SPW/2015-01#Plate'
 
-    def encode(self, obj):
-        v = super(Plate201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Plate201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Name', obj.name)
         self.set_if_not_none(v, 'Description', obj.description)
         self.set_if_not_none(v, 'ColumnNamingConvention',
@@ -39,7 +39,7 @@ class Plate201501Encoder(AnnotatableEncoder):
             for well in obj.copyWells():
                 well_encoder = self.ctx.get_encoder(well.__class__)
                 wells.append(
-                    well_encoder.encode(well)
+                    well_encoder.encode(well, False)
                 )
             v['Wells'] = wells
         return v

--- a/omero_marshal/encode/encoders/plateacquisition.py
+++ b/omero_marshal/encode/encoders/plateacquisition.py
@@ -18,8 +18,8 @@ class PlateAcquisition201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SPW/2015-01#PlateAcquisition'
 
-    def encode(self, obj):
-        v = super(PlateAcquisition201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(PlateAcquisition201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Name', obj.name)
         self.set_if_not_none(v, 'Description', obj.description)
         self.set_if_not_none(v, 'MaximumFieldCount', obj.maximumFieldCount)

--- a/omero_marshal/encode/encoders/point.py
+++ b/omero_marshal/encode/encoders/point.py
@@ -20,8 +20,8 @@ class Point201501Encoder(ShapeEncoder):
     X_PROPERTY_NAME = 'cx'
     Y_PROPERTY_NAME = 'cy'
 
-    def encode(self, obj):
-        v = super(Point201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Point201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'X', getattr(obj, self.X_PROPERTY_NAME))
         self.set_if_not_none(v, 'Y', getattr(obj, self.Y_PROPERTY_NAME))
         return v

--- a/omero_marshal/encode/encoders/polygon.py
+++ b/omero_marshal/encode/encoders/polygon.py
@@ -18,8 +18,8 @@ class Polygon201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Polygon'
 
-    def encode(self, obj):
-        v = super(Polygon201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Polygon201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Points', obj.points)
         return v
 

--- a/omero_marshal/encode/encoders/polyline.py
+++ b/omero_marshal/encode/encoders/polyline.py
@@ -18,8 +18,8 @@ class Polyline201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Polyline'
 
-    def encode(self, obj):
-        v = super(Polyline201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Polyline201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Points', obj.points)
         return v
 
@@ -28,8 +28,8 @@ class Polyline201606Encoder(Polyline201501Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Polyline'
 
-    def encode(self, obj):
-        v = super(Polyline201606Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Polyline201606Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'MarkerStart', obj.markerStart)
         self.set_if_not_none(v, 'MarkerEnd', obj.markerEnd)
         return v

--- a/omero_marshal/encode/encoders/project.py
+++ b/omero_marshal/encode/encoders/project.py
@@ -18,8 +18,8 @@ class Project201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Project'
 
-    def encode(self, obj):
-        v = super(Project201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Project201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Name', obj.name)
         self.set_if_not_none(v, 'Description', obj.description)
         if obj.isDatasetLinksLoaded() and obj.sizeOfDatasetLinks() > 0:
@@ -28,7 +28,7 @@ class Project201501Encoder(AnnotatableEncoder):
                 dataset = dataset_link.child
                 dataset_encoder = self.ctx.get_encoder(dataset.__class__)
                 datasets.append(
-                    dataset_encoder.encode(dataset)
+                    dataset_encoder.encode(dataset, False)
                 )
             v['Datasets'] = datasets
         return v

--- a/omero_marshal/encode/encoders/rectangle.py
+++ b/omero_marshal/encode/encoders/rectangle.py
@@ -25,8 +25,8 @@ class Rectangle201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Rectangle'
 
-    def encode(self, obj):
-        v = super(Rectangle201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Rectangle201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'X', obj.x)
         self.set_if_not_none(v, 'Y', obj.y)
         self.set_if_not_none(v, 'Width', obj.width)

--- a/omero_marshal/encode/encoders/roi.py
+++ b/omero_marshal/encode/encoders/roi.py
@@ -18,15 +18,15 @@ class Roi201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#ROI'
 
-    def encode(self, obj):
-        v = super(Roi201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Roi201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Name', obj.name)
         self.set_if_not_none(v, 'Description', obj.description)
         if obj.isShapesLoaded() and obj.sizeOfShapes() > 0:
             shapes = list()
             for shape in obj.copyShapes():
                 shape_encoder = self.ctx.get_encoder(shape.__class__)
-                shapes.append(shape_encoder.encode(shape))
+                shapes.append(shape_encoder.encode(shape, False))
             v['shapes'] = shapes
         return v
 

--- a/omero_marshal/encode/encoders/screen.py
+++ b/omero_marshal/encode/encoders/screen.py
@@ -18,8 +18,8 @@ class Screen201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SPW/2015-01#Screen'
 
-    def encode(self, obj):
-        v = super(Screen201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Screen201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Name', obj.name)
         self.set_if_not_none(v, 'Description', obj.description)
         self.set_if_not_none(v, 'ProtocolDescription', obj.protocolDescription)
@@ -35,7 +35,7 @@ class Screen201501Encoder(AnnotatableEncoder):
                 plate = plate_link.child
                 plate_encoder = self.ctx.get_encoder(plate.__class__)
                 plates.append(
-                    plate_encoder.encode(plate)
+                    plate_encoder.encode(plate, False)
                 )
             v['Plates'] = plates
         return v

--- a/omero_marshal/encode/encoders/shape.py
+++ b/omero_marshal/encode/encoders/shape.py
@@ -19,8 +19,8 @@ class Shape201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Shape'
 
-    def encode(self, obj):
-        v = super(Shape201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Shape201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'FillColor', obj.fillColor)
         self.set_if_not_none(v, 'FillRule', obj.fillRule)
         self.set_if_not_none(v, 'FontFamily', obj.fontFamily)
@@ -38,7 +38,7 @@ class Shape201501Encoder(AnnotatableEncoder):
         if transform:
             transform_encoder = self.ctx.get_encoder(transform.__class__)
             self.set_if_not_none(
-                v, 'Transform', transform_encoder.encode(transform))
+                v, 'Transform', transform_encoder.encode(transform, False))
         self.set_linecap(v, obj)
         self.set_visible(v, obj)
         return v

--- a/omero_marshal/encode/encoders/tag_annotation.py
+++ b/omero_marshal/encode/encoders/tag_annotation.py
@@ -19,8 +19,8 @@ class TagAnnotation201501Encoder(TextAnnotationEncoder):
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#TagAnnotation'
 
-    def encode(self, obj):
-        v = super(TagAnnotation201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(TagAnnotation201501Encoder, self).encode(obj, include_context)
         return v
 
 

--- a/omero_marshal/encode/encoders/term_annotation.py
+++ b/omero_marshal/encode/encoders/term_annotation.py
@@ -19,8 +19,8 @@ class TermAnnotation201501Encoder(AnnotationEncoder):
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#TermAnnotation'
 
-    def encode(self, obj):
-        v = super(TermAnnotation201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(TermAnnotation201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Value', obj.termValue)
         return v
 

--- a/omero_marshal/encode/encoders/text_annotation.py
+++ b/omero_marshal/encode/encoders/text_annotation.py
@@ -19,8 +19,8 @@ class TextAnnotation201501Encoder(AnnotationEncoder):
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#TextAnnotation'
 
-    def encode(self, obj):
-        v = super(TextAnnotation201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(TextAnnotation201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Value', obj.textValue)
         return v
 

--- a/omero_marshal/encode/encoders/timestamp_annotation.py
+++ b/omero_marshal/encode/encoders/timestamp_annotation.py
@@ -19,8 +19,8 @@ class TimestampAnnotation201501Encoder(AnnotationEncoder):
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#TimestampAnnotation'
 
-    def encode(self, obj):
-        v = super(TimestampAnnotation201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(TimestampAnnotation201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Value', obj.timeValue)
         return v
 

--- a/omero_marshal/encode/encoders/well.py
+++ b/omero_marshal/encode/encoders/well.py
@@ -18,8 +18,8 @@ class Well201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SPW/2015-01#Well'
 
-    def encode(self, obj):
-        v = super(Well201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(Well201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'Column', obj.column)
         self.set_if_not_none(v, 'Row', obj.row)
         self.set_if_not_none(v, 'ExternalDescription', obj.externalDescription)
@@ -36,7 +36,7 @@ class Well201501Encoder(AnnotatableEncoder):
                     continue
                 wellsample_encoder = self.ctx.get_encoder(wellsample.__class__)
                 wellsamples.append(
-                    wellsample_encoder.encode(wellsample)
+                    wellsample_encoder.encode(wellsample, False)
                 )
             v['WellSamples'] = wellsamples
         return v

--- a/omero_marshal/encode/encoders/wellsample.py
+++ b/omero_marshal/encode/encoders/wellsample.py
@@ -18,19 +18,19 @@ class WellSample201501Encoder(Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SPW/2015-01#WellSample'
 
-    def encode(self, obj):
-        v = super(WellSample201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(WellSample201501Encoder, self).encode(obj, include_context)
         self.set_if_not_none(v, 'PositionX', obj.posX)
         self.set_if_not_none(v, 'PositionY', obj.posY)
         self.set_if_not_none(v, 'Timepoint', obj.timepoint)
         if obj.image is not None and obj.image.isLoaded():
             image_encoder = self.ctx.get_encoder(obj.image.__class__)
-            v['Image'] = image_encoder.encode(obj.image)
+            v['Image'] = image_encoder.encode(obj.image, False)
 
         if obj.plateAcquisition is not None \
                 and obj.plateAcquisition.isLoaded():
             encoder = self.ctx.get_encoder(obj.plateAcquisition.__class__)
-            v['PlateAcquisition'] = encoder.encode(obj.plateAcquisition)
+            v['PlateAcquisition'] = encoder.encode(obj.plateAcquisition, False)
         return v
 
 

--- a/omero_marshal/encode/encoders/xml_annotation.py
+++ b/omero_marshal/encode/encoders/xml_annotation.py
@@ -19,8 +19,8 @@ class XmlAnnotation201501Encoder(TextAnnotationEncoder):
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#XmlAnnotation'
 
-    def encode(self, obj):
-        v = super(XmlAnnotation201501Encoder, self).encode(obj)
+    def encode(self, obj, include_context=None):
+        v = super(XmlAnnotation201501Encoder, self).encode(obj, include_context)
         return v
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,7 +11,7 @@
 
 import pytest
 
-from omero_marshal.encode import OME_CONTEXT, OMERO_CONTEXT
+from omero_marshal.encode import BASE_CONTEXT, OMERO_CONTEXT
 
 from omero.model import \
     AcquisitionModeI, \
@@ -716,7 +716,7 @@ def mask(identity_transform):
 def contexts():
     return {
         '@context': {
-            "ome": OME_CONTEXT,
+            "@base": BASE_CONTEXT,
             "omero": OMERO_CONTEXT,
         }
     }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,6 +11,8 @@
 
 import pytest
 
+from omero_marshal.encode import OME_CONTEXT, OMERO_CONTEXT
+
 from omero.model import \
     AcquisitionModeI, \
     BooleanAnnotationI, \
@@ -709,3 +711,12 @@ def mask(identity_transform):
     o.height = rdouble(2.0)
     o.id = rlong(8)
     return o
+
+@pytest.fixture()
+def contexts():
+    return {
+        '@context': {
+            "ome": OME_CONTEXT,
+            "omero": OMERO_CONTEXT,
+        }
+    }

--- a/tests/unit/test_affinetransform_encoders.py
+++ b/tests/unit/test_affinetransform_encoders.py
@@ -9,7 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder, SCHEMA_VERSION, ROI_SCHEMA_URL
+from omero_marshal import get_encoder, SCHEMA_VERSION
 from omero.rtypes import rdouble
 
 try:
@@ -33,7 +33,7 @@ def create_affine_transform(a00, a10, a01, a11, a02, a12):
     return t
 
 
-TRANSFORMATION_TYPE = '%s#AffineTransform' % ROI_SCHEMA_URL
+TRANSFORMATION_TYPE = 'AffineTransform'
 
 TRANSFORMATIONS = [
     (

--- a/tests/unit/test_affinetransform_encoders.py
+++ b/tests/unit/test_affinetransform_encoders.py
@@ -189,5 +189,5 @@ class TestAffineTransformEncoder():
             if SCHEMA_VERSION == '2015-01':
                 transform_o['@id'] = -1
             else:
-                transform_o['omero:details'] = {'@type': 'TBD#Details'}
+                transform_o['omero:details'] = {'@type': 'omero:Details'}
             assert v['Transform'] == transform_o

--- a/tests/unit/test_base_decoder.py
+++ b/tests/unit/test_base_decoder.py
@@ -12,17 +12,17 @@
 import json
 
 from omero.model import RoiI
-from omero_marshal import get_encoder, get_decoder, ROI_SCHEMA_URL
+from omero_marshal import get_encoder, get_decoder
 
 
 class TestBaseDecoder(object):
 
     AS_STRING = """{
-    "@type": "%s#ROI",
+    "@type": "ROI",
     "@id": 1,
     "Name": "the_name",
     "Description": "the_description"
-}""" % ROI_SCHEMA_URL
+}"""
 
     def assert_roi(self, roi, has_annotations=False):
         assert roi.__class__ == RoiI

--- a/tests/unit/test_base_encoder.py
+++ b/tests/unit/test_base_encoder.py
@@ -14,10 +14,11 @@ from omero_marshal import get_encoder, ROI_SCHEMA_URL, OME_SCHEMA_URL
 
 class TestBaseEncoder(object):
 
-    def test_base_encoder(self, roi):
+    def test_base_encoder_roi(self, roi, contexts):
         encoder = get_encoder(roi.__class__)
         v = encoder.encode(roi)
         assert v == {
+            **contexts,
             '@id': 1,
             '@type': '%s#ROI' % ROI_SCHEMA_URL,
             'Name': 'the_name',
@@ -70,22 +71,24 @@ class TestBaseEncoder(object):
             }
         }
 
-    def test_base_encoder_unloaded_details(self, roi):
+    def test_base_encoder_roi_unloaded_details(self, roi, contexts):
         roi.unloadDetails()
         encoder = get_encoder(roi.__class__)
         v = encoder.encode(roi)
         assert v == {
+            **contexts,
             '@id': 1,
             '@type': '%s#ROI' % ROI_SCHEMA_URL,
             'Name': 'the_name',
             'Description': 'the_description'
         }
 
-    def test_base_encoder_with_unloaded_details_children(
-            self, roi_with_unloaded_details_children):
+    def test_base_encoder_roi_with_unloaded_details_children(
+            self, roi_with_unloaded_details_children, contexts):
         encoder = get_encoder(roi_with_unloaded_details_children.__class__)
         v = encoder.encode(roi_with_unloaded_details_children)
         assert v == {
+            **contexts,
             '@id': 1,
             '@type': '%s#ROI' % ROI_SCHEMA_URL,
             'Name': 'the_name',
@@ -131,8 +134,9 @@ class TestBaseEncoder(object):
 
 class TestDetailsEncoder(object):
 
-    def experimenter_json(self):
+    def experimenter_json(self, contexts):
         return {
+            **contexts,
             '@id': 1,
             '@type': '%s#Experimenter' % OME_SCHEMA_URL,
             'FirstName': 'the_firstName',
@@ -144,13 +148,14 @@ class TestDetailsEncoder(object):
             'omero:details': {'@type': 'TBD#Details'}
         }
 
-    def test_experimenter_encoder(self, experimenter):
+    def test_experimenter_encoder(self, experimenter, contexts):
         encoder = get_encoder(experimenter.__class__)
         v = encoder.encode(experimenter)
-        assert v == self.experimenter_json()
+        assert v == self.experimenter_json(contexts)
 
-    def experimenter_group_json(self):
+    def experimenter_group_json(self, contexts):
         return {
+            **contexts,
             '@id': 1,
             '@type': '%s#ExperimenterGroup' % OME_SCHEMA_URL,
             'Name': 'the_name',
@@ -158,10 +163,10 @@ class TestDetailsEncoder(object):
             'omero:details': {'@type': 'TBD#Details'}
         }
 
-    def test_experimenter_group_encoder(self, experimenter_group):
+    def test_experimenter_group_encoder(self, experimenter_group, contexts):
         encoder = get_encoder(experimenter_group.__class__)
         v = encoder.encode(experimenter_group)
-        assert v == self.experimenter_group_json()
+        assert v == self.experimenter_group_json(contexts)
 
     def permissions_json(self):
         return {
@@ -202,13 +207,13 @@ class TestDetailsEncoder(object):
         v = encoder.encode(externalInfo)
         assert v == self.externalInfo_json()
 
-    def test_details_encoder(self, details):
+    def test_details_encoder(self, details, contexts):
         encoder = get_encoder(details.__class__)
         v = encoder.encode(details)
         assert v == {
             '@type': 'TBD#Details',
             'permissions': self.permissions_json(),
-            'owner': self.experimenter_json(),
-            'group': self.experimenter_group_json(),
+            'owner': self.experimenter_json({}),
+            'group': self.experimenter_group_json({}),
             'externalInfo': self.externalInfo_json(),
         }

--- a/tests/unit/test_base_encoder.py
+++ b/tests/unit/test_base_encoder.py
@@ -9,7 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder, ROI_SCHEMA_URL, OME_SCHEMA_URL
+from omero_marshal import get_encoder
 
 
 class TestBaseEncoder(object):
@@ -20,21 +20,21 @@ class TestBaseEncoder(object):
         assert v == {
             **contexts,
             '@id': 1,
-            '@type': '%s#ROI' % ROI_SCHEMA_URL,
+            '@type': 'ROI',
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {
                 '@type': 'omero:Details',
                 'group': {
                     '@id': 1,
-                    '@type': '%s#ExperimenterGroup' % OME_SCHEMA_URL,
+                    '@type': 'ExperimenterGroup',
                     'Description': 'the_description',
                     'Name': 'the_name',
                     'omero:details': {'@type': 'omero:Details'}
                 },
                 'owner': {
                     '@id': 1,
-                    '@type': '%s#Experimenter' % OME_SCHEMA_URL,
+                    '@type': 'Experimenter',
                     'Email': 'the_email',
                     'FirstName': 'the_firstName',
                     'Institution': 'the_institution',
@@ -78,7 +78,7 @@ class TestBaseEncoder(object):
         assert v == {
             **contexts,
             '@id': 1,
-            '@type': '%s#ROI' % ROI_SCHEMA_URL,
+            '@type': 'ROI',
             'Name': 'the_name',
             'Description': 'the_description'
         }
@@ -90,18 +90,18 @@ class TestBaseEncoder(object):
         assert v == {
             **contexts,
             '@id': 1,
-            '@type': '%s#ROI' % ROI_SCHEMA_URL,
+            '@type': 'ROI',
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {
                 '@type': 'omero:Details',
                 'owner': {
                     '@id': 1,
-                    '@type': '%s#Experimenter' % OME_SCHEMA_URL
+                    '@type': 'Experimenter'
                 },
                 'group': {
                     '@id': 1,
-                    '@type': '%s#ExperimenterGroup' % OME_SCHEMA_URL
+                    '@type': 'ExperimenterGroup'
                 },
                 'permissions': {
                     '@type': 'omero:Permissions',
@@ -138,7 +138,7 @@ class TestDetailsEncoder(object):
         return {
             **contexts,
             '@id': 1,
-            '@type': '%s#Experimenter' % OME_SCHEMA_URL,
+            '@type': 'Experimenter',
             'FirstName': 'the_firstName',
             'MiddleName': 'the_middleName',
             'LastName': 'the_lastName',
@@ -157,7 +157,7 @@ class TestDetailsEncoder(object):
         return {
             **contexts,
             '@id': 1,
-            '@type': '%s#ExperimenterGroup' % OME_SCHEMA_URL,
+            '@type': 'ExperimenterGroup',
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {'@type': 'omero:Details'}

--- a/tests/unit/test_base_encoder.py
+++ b/tests/unit/test_base_encoder.py
@@ -24,13 +24,13 @@ class TestBaseEncoder(object):
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {
-                '@type': 'TBD#Details',
+                '@type': 'omero:Details',
                 'group': {
                     '@id': 1,
                     '@type': '%s#ExperimenterGroup' % OME_SCHEMA_URL,
                     'Description': 'the_description',
                     'Name': 'the_name',
-                    'omero:details': {'@type': 'TBD#Details'}
+                    'omero:details': {'@type': 'omero:Details'}
                 },
                 'owner': {
                     '@id': 1,
@@ -41,10 +41,10 @@ class TestBaseEncoder(object):
                     'LastName': 'the_lastName',
                     'MiddleName': 'the_middleName',
                     'UserName': 'the_omeName',
-                    'omero:details': {'@type': 'TBD#Details'}
+                    'omero:details': {'@type': 'omero:Details'}
                 },
                 'permissions': {
-                    '@type': 'TBD#Permissions',
+                    '@type': 'omero:Permissions',
                     'canAnnotate': True,
                     'canDelete': True,
                     'canEdit': True,
@@ -59,13 +59,13 @@ class TestBaseEncoder(object):
                     'isWorldWrite': True
                 },
                 'externalInfo': {
-                    '@type': 'TBD#ExternalInfo',
+                    '@type': 'omero:ExternalInfo',
                     'EntityId': 123,
                     'EntityType': 'test',
                     'Lsid': 'ABCDEF',
                     'Uuid': 'f90a1fd5-275c-4d14-82b3-87b5ef0f07de',
                     'omero:details': {
-                        '@type': 'TBD#Details'
+                        '@type': 'omero:Details'
                     },
                 },
             }
@@ -94,7 +94,7 @@ class TestBaseEncoder(object):
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {
-                '@type': 'TBD#Details',
+                '@type': 'omero:Details',
                 'owner': {
                     '@id': 1,
                     '@type': '%s#Experimenter' % OME_SCHEMA_URL
@@ -104,7 +104,7 @@ class TestBaseEncoder(object):
                     '@type': '%s#ExperimenterGroup' % OME_SCHEMA_URL
                 },
                 'permissions': {
-                    '@type': 'TBD#Permissions',
+                    '@type': 'omero:Permissions',
                     'canAnnotate': True,
                     'canDelete': True,
                     'canEdit': True,
@@ -119,13 +119,13 @@ class TestBaseEncoder(object):
                     'isWorldWrite': True
                 },
                 'externalInfo': {
-                    '@type': 'TBD#ExternalInfo',
+                    '@type': 'omero:ExternalInfo',
                     'EntityId': 123,
                     'EntityType': 'test',
                     'Lsid': 'ABCDEF',
                     'Uuid': 'f90a1fd5-275c-4d14-82b3-87b5ef0f07de',
                     'omero:details': {
-                        '@type': 'TBD#Details'
+                        '@type': 'omero:Details'
                     },
                 },
             }
@@ -145,7 +145,7 @@ class TestDetailsEncoder(object):
             'Email': 'the_email',
             'Institution': 'the_institution',
             'UserName': 'the_omeName',
-            'omero:details': {'@type': 'TBD#Details'}
+            'omero:details': {'@type': 'omero:Details'}
         }
 
     def test_experimenter_encoder(self, experimenter, contexts):
@@ -160,7 +160,7 @@ class TestDetailsEncoder(object):
             '@type': '%s#ExperimenterGroup' % OME_SCHEMA_URL,
             'Name': 'the_name',
             'Description': 'the_description',
-            'omero:details': {'@type': 'TBD#Details'}
+            'omero:details': {'@type': 'omero:Details'}
         }
 
     def test_experimenter_group_encoder(self, experimenter_group, contexts):
@@ -170,7 +170,7 @@ class TestDetailsEncoder(object):
 
     def permissions_json(self):
         return {
-            '@type': 'TBD#Permissions',
+            '@type': 'omero:Permissions',
             'perm': 'rwrwrw',
             'canAnnotate': True,
             'canDelete': True,
@@ -192,13 +192,13 @@ class TestDetailsEncoder(object):
 
     def externalInfo_json(self):
         return {
-            '@type': 'TBD#ExternalInfo',
+            '@type': 'omero:ExternalInfo',
             'EntityId': 123,
             'EntityType': 'test',
             'Lsid': 'ABCDEF',
             'Uuid': 'f90a1fd5-275c-4d14-82b3-87b5ef0f07de',
             'omero:details': {
-                '@type': 'TBD#Details'
+                '@type': 'omero:Details'
             },
         }
 
@@ -211,7 +211,7 @@ class TestDetailsEncoder(object):
         encoder = get_encoder(details.__class__)
         v = encoder.encode(details)
         assert v == {
-            '@type': 'TBD#Details',
+            '@type': 'omero:Details',
             'permissions': self.permissions_json(),
             'owner': self.experimenter_json({}),
             'group': self.experimenter_group_json({}),

--- a/tests/unit/test_container_encoders.py
+++ b/tests/unit/test_container_encoders.py
@@ -9,7 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder, OME_SCHEMA_URL, SPW_SCHEMA_URL
+from omero_marshal import get_encoder
 
 
 class TestProjectEncoder(object):
@@ -20,7 +20,7 @@ class TestProjectEncoder(object):
         assert v == {
             **contexts,
             '@id': 1,
-            '@type': '%s#Project' % OME_SCHEMA_URL,
+            '@type': 'Project',
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {'@type': 'omero:Details'}
@@ -32,19 +32,19 @@ class TestProjectEncoder(object):
         assert v == {
             **contexts,
             '@id': 1,
-            '@type': '%s#Project' % OME_SCHEMA_URL,
+            '@type': 'Project',
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {'@type': 'omero:Details'},
             'Datasets': [{
                 '@id': 1,
-                '@type': '%s#Dataset' % OME_SCHEMA_URL,
+                '@type': 'Dataset',
                 'Name': 'dataset_name_1',
                 'Description': 'dataset_description_1',
                 'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@id': 2,
-                '@type': '%s#Dataset' % OME_SCHEMA_URL,
+                '@type': 'Dataset',
                 'Name': 'dataset_name_2',
                 'Description': 'dataset_description_2',
                 'omero:details': {'@type': 'omero:Details'}
@@ -58,19 +58,19 @@ class TestProjectEncoder(object):
         assert v == {
             **contexts,
             '@id': 1,
-            '@type': '%s#Project' % OME_SCHEMA_URL,
+            '@type': 'Project',
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {'@type': 'omero:Details'},
             'Datasets': [{
                 '@id': 1,
-                '@type': '%s#Dataset' % OME_SCHEMA_URL,
+                '@type': 'Dataset',
                 'Name': 'dataset_name_1',
                 'Description': 'dataset_description_1',
                 'omero:details': {'@type': 'omero:Details'},
                 'Images': [{
                     '@id': 1,
-                    '@type': '%s#Image' % OME_SCHEMA_URL,
+                    '@type': 'Image',
                     'AcquisitionDate': 1,
                     'Name': 'image_name_1',
                     'omero:archived': False,
@@ -86,7 +86,7 @@ class TestProjectEncoder(object):
                     'omero:details': {'@type': 'omero:Details'}
                 }, {
                     '@id': 2,
-                    '@type': '%s#Image' % OME_SCHEMA_URL,
+                    '@type': 'Image',
                     'AcquisitionDate': 1,
                     'Name': 'image_name_2',
                     'omero:archived': False,
@@ -103,13 +103,13 @@ class TestProjectEncoder(object):
                 }]
             }, {
                 '@id': 2,
-                '@type': '%s#Dataset' % OME_SCHEMA_URL,
+                '@type': 'Dataset',
                 'Name': 'dataset_name_2',
                 'Description': 'dataset_description_2',
                 'omero:details': {'@type': 'omero:Details'},
                 'Images': [{
                     '@id': 3,
-                    '@type': '%s#Image' % OME_SCHEMA_URL,
+                    '@type': 'Image',
                     'AcquisitionDate': 1,
                     'Name': 'image_name_3',
                     'omero:archived': False,
@@ -125,7 +125,7 @@ class TestProjectEncoder(object):
                     'omero:details': {'@type': 'omero:Details'}
                 }, {
                     '@id': 4,
-                    '@type': '%s#Image' % OME_SCHEMA_URL,
+                    '@type': 'Image',
                     'AcquisitionDate': 1,
                     'Name': 'image_name_4',
                     'omero:archived': False,
@@ -152,7 +152,7 @@ class TestScreenEncoder(object):
         assert v == {
             **contexts,
             '@id': 4,
-            '@type': '%s#Screen' % SPW_SCHEMA_URL,
+            '@type': 'Screen',
             'Name': 'the_name',
             'Description': 'the_description',
             'ProtocolDescription': 'the_protocol_description',
@@ -169,7 +169,7 @@ class TestScreenEncoder(object):
         assert v == {
             **contexts,
             '@id': 4,
-            '@type': '%s#Screen' % SPW_SCHEMA_URL,
+            '@type': 'Screen',
             'Name': 'the_name',
             'Description': 'the_description',
             'ProtocolDescription': 'the_protocol_description',
@@ -180,7 +180,7 @@ class TestScreenEncoder(object):
             'omero:details': {'@type': 'omero:Details'},
             'Plates': [{
                 '@id': 5,
-                '@type': '%s#Plate' % SPW_SCHEMA_URL,
+                '@type': 'Plate',
                 'Name': 'plate_name_5',
                 'Description': 'plate_description_5',
                 'ColumnNamingConvention': 'number',
@@ -204,7 +204,7 @@ class TestScreenEncoder(object):
                 },
                 'Wells': [{
                     '@id': 7,
-                    '@type': '%s#Well' % SPW_SCHEMA_URL,
+                    '@type': 'Well',
                     'Column': 2,
                     'Row': 1,
                     'ExternalDescription': 'external_description_7',
@@ -214,7 +214,7 @@ class TestScreenEncoder(object):
                     'omero:status': 'the_status',
                     'WellSamples': [{
                         '@id': 9,
-                        '@type': '%s#WellSample' % SPW_SCHEMA_URL,
+                        '@type': 'WellSample',
                         'PositionX': {
                             '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
@@ -230,7 +230,7 @@ class TestScreenEncoder(object):
                         'Timepoint': 1,
                         'Image': {
                             '@id': 1,
-                            '@type': '%s#Image' % OME_SCHEMA_URL,
+                            '@type': 'Image',
                             'AcquisitionDate': 1,
                             'Name': 'image_name_1',
                             'omero:archived': False,
@@ -247,7 +247,7 @@ class TestScreenEncoder(object):
                         },
                         'PlateAcquisition': {
                             '@id': 7,
-                            '@type': '%s#PlateAcquisition' % SPW_SCHEMA_URL,
+                            '@type': 'PlateAcquisition',
                             'Description': 'plateacquisition_description_7',
                             'EndTime': 2,
                             'MaximumFieldCount': 1,
@@ -258,7 +258,7 @@ class TestScreenEncoder(object):
                         'omero:details': {'@type': 'omero:Details'}
                     }, {
                         '@id': 10,
-                        '@type': '%s#WellSample' % SPW_SCHEMA_URL,
+                        '@type': 'WellSample',
                         'PositionX': {
                             '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
@@ -274,7 +274,7 @@ class TestScreenEncoder(object):
                         'Timepoint': 1,
                         'Image': {
                             '@id': 1,
-                            '@type': '%s#Image' % OME_SCHEMA_URL,
+                            '@type': 'Image',
                             'AcquisitionDate': 1,
                             'Name': 'image_name_1',
                             'omero:archived': False,
@@ -291,7 +291,7 @@ class TestScreenEncoder(object):
                         },
                         'PlateAcquisition': {
                             '@id': 7,
-                            '@type': '%s#PlateAcquisition' % SPW_SCHEMA_URL,
+                            '@type': 'PlateAcquisition',
                             'Description': 'plateacquisition_description_7',
                             'EndTime': 2,
                             'MaximumFieldCount': 1,
@@ -304,7 +304,7 @@ class TestScreenEncoder(object):
                     'omero:details': {'@type': 'omero:Details'}
                 }, {
                     '@id': 8,
-                    '@type': '%s#Well' % SPW_SCHEMA_URL,
+                    '@type': 'Well',
                     'Column': 2,
                     'Row': 1,
                     'ExternalDescription': 'external_description_8',
@@ -314,7 +314,7 @@ class TestScreenEncoder(object):
                     'omero:status': 'the_status',
                     'WellSamples': [{
                         '@id': 9,
-                        '@type': '%s#WellSample' % SPW_SCHEMA_URL,
+                        '@type': 'WellSample',
                         'PositionX': {
                             '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
@@ -330,7 +330,7 @@ class TestScreenEncoder(object):
                         'Timepoint': 1,
                         'Image': {
                             '@id': 1,
-                            '@type': '%s#Image' % OME_SCHEMA_URL,
+                            '@type': 'Image',
                             'AcquisitionDate': 1,
                             'Name': 'image_name_1',
                             'omero:archived': False,
@@ -347,7 +347,7 @@ class TestScreenEncoder(object):
                         },
                         'PlateAcquisition': {
                             '@id': 8,
-                            '@type': '%s#PlateAcquisition' % SPW_SCHEMA_URL,
+                            '@type': 'PlateAcquisition',
                             'Description': 'plateacquisition_description_8',
                             'EndTime': 2,
                             'MaximumFieldCount': 1,
@@ -358,7 +358,7 @@ class TestScreenEncoder(object):
                         'omero:details': {'@type': 'omero:Details'}
                     }, {
                         '@id': 10,
-                        '@type': '%s#WellSample' % SPW_SCHEMA_URL,
+                        '@type': 'WellSample',
                         'PositionX': {
                             '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
@@ -374,7 +374,7 @@ class TestScreenEncoder(object):
                         'Timepoint': 1,
                         'Image': {
                             '@id': 1,
-                            '@type': '%s#Image' % OME_SCHEMA_URL,
+                            '@type': 'Image',
                             'AcquisitionDate': 1,
                             'Name': 'image_name_1',
                             'omero:archived': False,
@@ -391,7 +391,7 @@ class TestScreenEncoder(object):
                         },
                         'PlateAcquisition': {
                             '@id': 8,
-                            '@type': '%s#PlateAcquisition' % SPW_SCHEMA_URL,
+                            '@type': 'PlateAcquisition',
                             'Description': 'plateacquisition_description_8',
                             'EndTime': 2,
                             'MaximumFieldCount': 1,
@@ -406,7 +406,7 @@ class TestScreenEncoder(object):
                 'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@id': 6,
-                '@type': '%s#Plate' % SPW_SCHEMA_URL,
+                '@type': 'Plate',
                 'Name': 'plate_name_6',
                 'Description': 'plate_description_6',
                 'ColumnNamingConvention': 'number',
@@ -430,7 +430,7 @@ class TestScreenEncoder(object):
                 },
                 'Wells': [{
                     '@id': 7,
-                    '@type': '%s#Well' % SPW_SCHEMA_URL,
+                    '@type': 'Well',
                     'Column': 2,
                     'Row': 1,
                     'ExternalDescription': 'external_description_7',
@@ -440,7 +440,7 @@ class TestScreenEncoder(object):
                     'omero:status': 'the_status',
                     'WellSamples': [{
                         '@id': 9,
-                        '@type': '%s#WellSample' % SPW_SCHEMA_URL,
+                        '@type': 'WellSample',
                         'PositionX': {
                             '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
@@ -456,7 +456,7 @@ class TestScreenEncoder(object):
                         'Timepoint': 1,
                         'Image': {
                             '@id': 1,
-                            '@type': '%s#Image' % OME_SCHEMA_URL,
+                            '@type': 'Image',
                             'AcquisitionDate': 1,
                             'Name': 'image_name_1',
                             'omero:archived': False,
@@ -473,7 +473,7 @@ class TestScreenEncoder(object):
                         },
                         'PlateAcquisition': {
                             '@id': 7,
-                            '@type': '%s#PlateAcquisition' % SPW_SCHEMA_URL,
+                            '@type': 'PlateAcquisition',
                             'Description': 'plateacquisition_description_7',
                             'EndTime': 2,
                             'MaximumFieldCount': 1,
@@ -484,7 +484,7 @@ class TestScreenEncoder(object):
                         'omero:details': {'@type': 'omero:Details'}
                     }, {
                         '@id': 10,
-                        '@type': '%s#WellSample' % SPW_SCHEMA_URL,
+                        '@type': 'WellSample',
                         'PositionX': {
                             '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
@@ -500,7 +500,7 @@ class TestScreenEncoder(object):
                         'Timepoint': 1,
                         'Image': {
                             '@id': 1,
-                            '@type': '%s#Image' % OME_SCHEMA_URL,
+                            '@type': 'Image',
                             'AcquisitionDate': 1,
                             'Name': 'image_name_1',
                             'omero:archived': False,
@@ -517,7 +517,7 @@ class TestScreenEncoder(object):
                         },
                         'PlateAcquisition': {
                             '@id': 7,
-                            '@type': '%s#PlateAcquisition' % SPW_SCHEMA_URL,
+                            '@type': 'PlateAcquisition',
                             'Description': 'plateacquisition_description_7',
                             'EndTime': 2,
                             'MaximumFieldCount': 1,
@@ -530,7 +530,7 @@ class TestScreenEncoder(object):
                     'omero:details': {'@type': 'omero:Details'}
                 }, {
                     '@id': 8,
-                    '@type': '%s#Well' % SPW_SCHEMA_URL,
+                    '@type': 'Well',
                     'Column': 2,
                     'Row': 1,
                     'ExternalDescription': 'external_description_8',
@@ -540,7 +540,7 @@ class TestScreenEncoder(object):
                     'omero:status': 'the_status',
                     'WellSamples': [{
                         '@id': 9,
-                        '@type': '%s#WellSample' % SPW_SCHEMA_URL,
+                        '@type': 'WellSample',
                         'PositionX': {
                             '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
@@ -556,7 +556,7 @@ class TestScreenEncoder(object):
                         'Timepoint': 1,
                         'Image': {
                             '@id': 1,
-                            '@type': '%s#Image' % OME_SCHEMA_URL,
+                            '@type': 'Image',
                             'AcquisitionDate': 1,
                             'Name': 'image_name_1',
                             'omero:archived': False,
@@ -573,7 +573,7 @@ class TestScreenEncoder(object):
                         },
                         'PlateAcquisition': {
                             '@id': 8,
-                            '@type': '%s#PlateAcquisition' % SPW_SCHEMA_URL,
+                            '@type': 'PlateAcquisition',
                             'Description': 'plateacquisition_description_8',
                             'EndTime': 2,
                             'MaximumFieldCount': 1,
@@ -584,7 +584,7 @@ class TestScreenEncoder(object):
                         'omero:details': {'@type': 'omero:Details'}
                     }, {
                         '@id': 10,
-                        '@type': '%s#WellSample' % SPW_SCHEMA_URL,
+                        '@type': 'WellSample',
                         'PositionX': {
                             '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
@@ -600,7 +600,7 @@ class TestScreenEncoder(object):
                         'Timepoint': 1,
                         'Image': {
                             '@id': 1,
-                            '@type': '%s#Image' % OME_SCHEMA_URL,
+                            '@type': 'Image',
                             'AcquisitionDate': 1,
                             'Name': 'image_name_1',
                             'omero:archived': False,
@@ -617,7 +617,7 @@ class TestScreenEncoder(object):
                         },
                         'PlateAcquisition': {
                             '@id': 8,
-                            '@type': '%s#PlateAcquisition' % SPW_SCHEMA_URL,
+                            '@type': 'PlateAcquisition',
                             'Description': 'plateacquisition_description_8',
                             'EndTime': 2,
                             'MaximumFieldCount': 1,

--- a/tests/unit/test_container_encoders.py
+++ b/tests/unit/test_container_encoders.py
@@ -14,10 +14,11 @@ from omero_marshal import get_encoder, OME_SCHEMA_URL, SPW_SCHEMA_URL
 
 class TestProjectEncoder(object):
 
-    def test_project_encoder(self, project):
+    def test_project_encoder(self, project, contexts):
         encoder = get_encoder(project.__class__)
         v = encoder.encode(project)
         assert v == {
+            **contexts,
             '@id': 1,
             '@type': '%s#Project' % OME_SCHEMA_URL,
             'Name': 'the_name',
@@ -25,10 +26,11 @@ class TestProjectEncoder(object):
             'omero:details': {'@type': 'TBD#Details'}
         }
 
-    def test_project_with_datasets_encoder(self, project_with_datasets):
+    def test_project_with_datasets_encoder(self, project_with_datasets, contexts):
         encoder = get_encoder(project_with_datasets.__class__)
         v = encoder.encode(project_with_datasets)
         assert v == {
+            **contexts,
             '@id': 1,
             '@type': '%s#Project' % OME_SCHEMA_URL,
             'Name': 'the_name',
@@ -50,10 +52,11 @@ class TestProjectEncoder(object):
         }
 
     def test_project_with_datasets_and_images_encoder(
-            self, project_with_datasets_and_images):
+            self, project_with_datasets_and_images, contexts):
         encoder = get_encoder(project_with_datasets_and_images.__class__)
         v = encoder.encode(project_with_datasets_and_images)
         assert v == {
+            **contexts,
             '@id': 1,
             '@type': '%s#Project' % OME_SCHEMA_URL,
             'Name': 'the_name',
@@ -143,10 +146,11 @@ class TestProjectEncoder(object):
 
 class TestScreenEncoder(object):
 
-    def test_screen_encoder(self, screen):
+    def test_screen_encoder(self, screen, contexts):
         encoder = get_encoder(screen.__class__)
         v = encoder.encode(screen)
         assert v == {
+            **contexts,
             '@id': 4,
             '@type': '%s#Screen' % SPW_SCHEMA_URL,
             'Name': 'the_name',
@@ -159,10 +163,11 @@ class TestScreenEncoder(object):
             'omero:details': {'@type': 'TBD#Details'}
         }
 
-    def test_screen_with_plate_encoder(self, screen_with_plates):
+    def test_screen_with_plate_encoder(self, screen_with_plates, contexts):
         encoder = get_encoder(screen_with_plates.__class__)
         v = encoder.encode(screen_with_plates)
         assert v == {
+            **contexts,
             '@id': 4,
             '@type': '%s#Screen' % SPW_SCHEMA_URL,
             'Name': 'the_name',

--- a/tests/unit/test_container_encoders.py
+++ b/tests/unit/test_container_encoders.py
@@ -23,7 +23,7 @@ class TestProjectEncoder(object):
             '@type': '%s#Project' % OME_SCHEMA_URL,
             'Name': 'the_name',
             'Description': 'the_description',
-            'omero:details': {'@type': 'TBD#Details'}
+            'omero:details': {'@type': 'omero:Details'}
         }
 
     def test_project_with_datasets_encoder(self, project_with_datasets, contexts):
@@ -35,19 +35,19 @@ class TestProjectEncoder(object):
             '@type': '%s#Project' % OME_SCHEMA_URL,
             'Name': 'the_name',
             'Description': 'the_description',
-            'omero:details': {'@type': 'TBD#Details'},
+            'omero:details': {'@type': 'omero:Details'},
             'Datasets': [{
                 '@id': 1,
                 '@type': '%s#Dataset' % OME_SCHEMA_URL,
                 'Name': 'dataset_name_1',
                 'Description': 'dataset_description_1',
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@id': 2,
                 '@type': '%s#Dataset' % OME_SCHEMA_URL,
                 'Name': 'dataset_name_2',
                 'Description': 'dataset_description_2',
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }]
         }
 
@@ -61,13 +61,13 @@ class TestProjectEncoder(object):
             '@type': '%s#Project' % OME_SCHEMA_URL,
             'Name': 'the_name',
             'Description': 'the_description',
-            'omero:details': {'@type': 'TBD#Details'},
+            'omero:details': {'@type': 'omero:Details'},
             'Datasets': [{
                 '@id': 1,
                 '@type': '%s#Dataset' % OME_SCHEMA_URL,
                 'Name': 'dataset_name_1',
                 'Description': 'dataset_description_1',
-                'omero:details': {'@type': 'TBD#Details'},
+                'omero:details': {'@type': 'omero:Details'},
                 'Images': [{
                     '@id': 1,
                     '@type': '%s#Image' % OME_SCHEMA_URL,
@@ -79,11 +79,11 @@ class TestProjectEncoder(object):
                     'omero:series': 0,
                     'omero:format': {
                         '@id': 1,
-                        '@type': 'TBD#Format',
+                        '@type': 'omero:Format',
                         'value': 'PNG',
-                        'omero:details': {'@type': 'TBD#Details'},
+                        'omero:details': {'@type': 'omero:Details'},
                     },
-                    'omero:details': {'@type': 'TBD#Details'}
+                    'omero:details': {'@type': 'omero:Details'}
                 }, {
                     '@id': 2,
                     '@type': '%s#Image' % OME_SCHEMA_URL,
@@ -95,18 +95,18 @@ class TestProjectEncoder(object):
                     'omero:series': 0,
                     'omero:format': {
                         '@id': 1,
-                        '@type': 'TBD#Format',
+                        '@type': 'omero:Format',
                         'value': 'PNG',
-                        'omero:details': {'@type': 'TBD#Details'},
+                        'omero:details': {'@type': 'omero:Details'},
                     },
-                    'omero:details': {'@type': 'TBD#Details'}
+                    'omero:details': {'@type': 'omero:Details'}
                 }]
             }, {
                 '@id': 2,
                 '@type': '%s#Dataset' % OME_SCHEMA_URL,
                 'Name': 'dataset_name_2',
                 'Description': 'dataset_description_2',
-                'omero:details': {'@type': 'TBD#Details'},
+                'omero:details': {'@type': 'omero:Details'},
                 'Images': [{
                     '@id': 3,
                     '@type': '%s#Image' % OME_SCHEMA_URL,
@@ -118,11 +118,11 @@ class TestProjectEncoder(object):
                     'omero:series': 0,
                     'omero:format': {
                         '@id': 1,
-                        '@type': 'TBD#Format',
+                        '@type': 'omero:Format',
                         'value': 'PNG',
-                        'omero:details': {'@type': 'TBD#Details'},
+                        'omero:details': {'@type': 'omero:Details'},
                     },
-                    'omero:details': {'@type': 'TBD#Details'}
+                    'omero:details': {'@type': 'omero:Details'}
                 }, {
                     '@id': 4,
                     '@type': '%s#Image' % OME_SCHEMA_URL,
@@ -134,11 +134,11 @@ class TestProjectEncoder(object):
                     'omero:series': 0,
                     'omero:format': {
                         '@id': 1,
-                        '@type': 'TBD#Format',
+                        '@type': 'omero:Format',
                         'value': 'PNG',
-                        'omero:details': {'@type': 'TBD#Details'},
+                        'omero:details': {'@type': 'omero:Details'},
                     },
-                    'omero:details': {'@type': 'TBD#Details'}
+                    'omero:details': {'@type': 'omero:Details'}
                 }]
             }]
         }
@@ -160,7 +160,7 @@ class TestScreenEncoder(object):
             'ReagentSetDescription': 'the_reagent_set_description',
             'ReagentSetIdentifier': 'the_reagent_set_identifier',
             'Type': 'the_type',
-            'omero:details': {'@type': 'TBD#Details'}
+            'omero:details': {'@type': 'omero:Details'}
         }
 
     def test_screen_with_plate_encoder(self, screen_with_plates, contexts):
@@ -177,7 +177,7 @@ class TestScreenEncoder(object):
             'ReagentSetDescription': 'the_reagent_set_description',
             'ReagentSetIdentifier': 'the_reagent_set_identifier',
             'Type': 'the_type',
-            'omero:details': {'@type': 'TBD#Details'},
+            'omero:details': {'@type': 'omero:Details'},
             'Plates': [{
                 '@id': 5,
                 '@type': '%s#Plate' % SPW_SCHEMA_URL,
@@ -191,13 +191,13 @@ class TestScreenEncoder(object):
                 'ExternalIdentifier': 'external_identifier_5',
                 'Status': 'status_5',
                 'WellOriginX': {
-                    '@type': 'TBD#LengthI',
+                    '@type': 'omero:LengthI',
                     'Unit': 'REFERENCEFRAME',
                     'Symbol': 'reference frame',
                     'Value': 0.1
                 },
                 'WellOriginY': {
-                    '@type': 'TBD#LengthI',
+                    '@type': 'omero:LengthI',
                     'Unit': 'REFERENCEFRAME',
                     'Symbol': 'reference frame',
                     'Value': 1.1
@@ -216,13 +216,13 @@ class TestScreenEncoder(object):
                         '@id': 9,
                         '@type': '%s#WellSample' % SPW_SCHEMA_URL,
                         'PositionX': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 1.0
                         },
                         'PositionY': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 2.0
@@ -239,11 +239,11 @@ class TestScreenEncoder(object):
                             'omero:series': 0,
                             'omero:format': {
                                 '@id': 1,
-                                '@type': 'TBD#Format',
+                                '@type': 'omero:Format',
                                 'value': 'PNG',
-                                'omero:details': {'@type': 'TBD#Details'},
+                                'omero:details': {'@type': 'omero:Details'},
                             },
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
                         'PlateAcquisition': {
                             '@id': 7,
@@ -253,20 +253,20 @@ class TestScreenEncoder(object):
                             'MaximumFieldCount': 1,
                             'Name': 'plateacquisition_name_7',
                             'StartTime': 1,
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
-                        'omero:details': {'@type': 'TBD#Details'}
+                        'omero:details': {'@type': 'omero:Details'}
                     }, {
                         '@id': 10,
                         '@type': '%s#WellSample' % SPW_SCHEMA_URL,
                         'PositionX': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 1.0
                         },
                         'PositionY': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 2.0
@@ -283,11 +283,11 @@ class TestScreenEncoder(object):
                             'omero:series': 0,
                             'omero:format': {
                                 '@id': 1,
-                                '@type': 'TBD#Format',
+                                '@type': 'omero:Format',
                                 'value': 'PNG',
-                                'omero:details': {'@type': 'TBD#Details'},
+                                'omero:details': {'@type': 'omero:Details'},
                             },
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
                         'PlateAcquisition': {
                             '@id': 7,
@@ -297,11 +297,11 @@ class TestScreenEncoder(object):
                             'MaximumFieldCount': 1,
                             'Name': 'plateacquisition_name_7',
                             'StartTime': 1,
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
-                        'omero:details': {'@type': 'TBD#Details'}
+                        'omero:details': {'@type': 'omero:Details'}
                     }],
-                    'omero:details': {'@type': 'TBD#Details'}
+                    'omero:details': {'@type': 'omero:Details'}
                 }, {
                     '@id': 8,
                     '@type': '%s#Well' % SPW_SCHEMA_URL,
@@ -316,13 +316,13 @@ class TestScreenEncoder(object):
                         '@id': 9,
                         '@type': '%s#WellSample' % SPW_SCHEMA_URL,
                         'PositionX': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 1.0
                         },
                         'PositionY': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 2.0
@@ -339,11 +339,11 @@ class TestScreenEncoder(object):
                             'omero:series': 0,
                             'omero:format': {
                                 '@id': 1,
-                                '@type': 'TBD#Format',
+                                '@type': 'omero:Format',
                                 'value': 'PNG',
-                                'omero:details': {'@type': 'TBD#Details'},
+                                'omero:details': {'@type': 'omero:Details'},
                             },
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
                         'PlateAcquisition': {
                             '@id': 8,
@@ -353,20 +353,20 @@ class TestScreenEncoder(object):
                             'MaximumFieldCount': 1,
                             'Name': 'plateacquisition_name_8',
                             'StartTime': 1,
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
-                        'omero:details': {'@type': 'TBD#Details'}
+                        'omero:details': {'@type': 'omero:Details'}
                     }, {
                         '@id': 10,
                         '@type': '%s#WellSample' % SPW_SCHEMA_URL,
                         'PositionX': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 1.0
                         },
                         'PositionY': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 2.0
@@ -383,11 +383,11 @@ class TestScreenEncoder(object):
                             'omero:series': 0,
                             'omero:format': {
                                 '@id': 1,
-                                '@type': 'TBD#Format',
+                                '@type': 'omero:Format',
                                 'value': 'PNG',
-                                'omero:details': {'@type': 'TBD#Details'},
+                                'omero:details': {'@type': 'omero:Details'},
                             },
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
                         'PlateAcquisition': {
                             '@id': 8,
@@ -397,13 +397,13 @@ class TestScreenEncoder(object):
                             'MaximumFieldCount': 1,
                             'Name': 'plateacquisition_name_8',
                             'StartTime': 1,
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
-                        'omero:details': {'@type': 'TBD#Details'}
+                        'omero:details': {'@type': 'omero:Details'}
                     }],
-                    'omero:details': {'@type': 'TBD#Details'}
+                    'omero:details': {'@type': 'omero:Details'}
                 }],
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@id': 6,
                 '@type': '%s#Plate' % SPW_SCHEMA_URL,
@@ -417,13 +417,13 @@ class TestScreenEncoder(object):
                 'ExternalIdentifier': 'external_identifier_6',
                 'Status': 'status_6',
                 'WellOriginX': {
-                    '@type': 'TBD#LengthI',
+                    '@type': 'omero:LengthI',
                     'Unit': 'REFERENCEFRAME',
                     'Symbol': 'reference frame',
                     'Value': 0.1
                 },
                 'WellOriginY': {
-                    '@type': 'TBD#LengthI',
+                    '@type': 'omero:LengthI',
                     'Unit': 'REFERENCEFRAME',
                     'Symbol': 'reference frame',
                     'Value': 1.1
@@ -442,13 +442,13 @@ class TestScreenEncoder(object):
                         '@id': 9,
                         '@type': '%s#WellSample' % SPW_SCHEMA_URL,
                         'PositionX': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 1.0
                         },
                         'PositionY': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 2.0
@@ -465,11 +465,11 @@ class TestScreenEncoder(object):
                             'omero:series': 0,
                             'omero:format': {
                                 '@id': 1,
-                                '@type': 'TBD#Format',
+                                '@type': 'omero:Format',
                                 'value': 'PNG',
-                                'omero:details': {'@type': 'TBD#Details'},
+                                'omero:details': {'@type': 'omero:Details'},
                             },
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
                         'PlateAcquisition': {
                             '@id': 7,
@@ -479,20 +479,20 @@ class TestScreenEncoder(object):
                             'MaximumFieldCount': 1,
                             'Name': 'plateacquisition_name_7',
                             'StartTime': 1,
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
-                        'omero:details': {'@type': 'TBD#Details'}
+                        'omero:details': {'@type': 'omero:Details'}
                     }, {
                         '@id': 10,
                         '@type': '%s#WellSample' % SPW_SCHEMA_URL,
                         'PositionX': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 1.0
                         },
                         'PositionY': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 2.0
@@ -509,11 +509,11 @@ class TestScreenEncoder(object):
                             'omero:series': 0,
                             'omero:format': {
                                 '@id': 1,
-                                '@type': 'TBD#Format',
+                                '@type': 'omero:Format',
                                 'value': 'PNG',
-                                'omero:details': {'@type': 'TBD#Details'},
+                                'omero:details': {'@type': 'omero:Details'},
                             },
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
                         'PlateAcquisition': {
                             '@id': 7,
@@ -523,11 +523,11 @@ class TestScreenEncoder(object):
                             'MaximumFieldCount': 1,
                             'Name': 'plateacquisition_name_7',
                             'StartTime': 1,
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
-                        'omero:details': {'@type': 'TBD#Details'}
+                        'omero:details': {'@type': 'omero:Details'}
                     }],
-                    'omero:details': {'@type': 'TBD#Details'}
+                    'omero:details': {'@type': 'omero:Details'}
                 }, {
                     '@id': 8,
                     '@type': '%s#Well' % SPW_SCHEMA_URL,
@@ -542,13 +542,13 @@ class TestScreenEncoder(object):
                         '@id': 9,
                         '@type': '%s#WellSample' % SPW_SCHEMA_URL,
                         'PositionX': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 1.0
                         },
                         'PositionY': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 2.0
@@ -565,11 +565,11 @@ class TestScreenEncoder(object):
                             'omero:series': 0,
                             'omero:format': {
                                 '@id': 1,
-                                '@type': 'TBD#Format',
+                                '@type': 'omero:Format',
                                 'value': 'PNG',
-                                'omero:details': {'@type': 'TBD#Details'},
+                                'omero:details': {'@type': 'omero:Details'},
                             },
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
                         'PlateAcquisition': {
                             '@id': 8,
@@ -579,20 +579,20 @@ class TestScreenEncoder(object):
                             'MaximumFieldCount': 1,
                             'Name': 'plateacquisition_name_8',
                             'StartTime': 1,
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
-                        'omero:details': {'@type': 'TBD#Details'}
+                        'omero:details': {'@type': 'omero:Details'}
                     }, {
                         '@id': 10,
                         '@type': '%s#WellSample' % SPW_SCHEMA_URL,
                         'PositionX': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 1.0
                         },
                         'PositionY': {
-                            '@type': 'TBD#LengthI',
+                            '@type': 'omero:LengthI',
                             'Unit': 'REFERENCEFRAME',
                             'Symbol': 'reference frame',
                             'Value': 2.0
@@ -609,11 +609,11 @@ class TestScreenEncoder(object):
                             'omero:series': 0,
                             'omero:format': {
                                 '@id': 1,
-                                '@type': 'TBD#Format',
+                                '@type': 'omero:Format',
                                 'value': 'PNG',
-                                'omero:details': {'@type': 'TBD#Details'},
+                                'omero:details': {'@type': 'omero:Details'},
                             },
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
                         'PlateAcquisition': {
                             '@id': 8,
@@ -623,12 +623,12 @@ class TestScreenEncoder(object):
                             'MaximumFieldCount': 1,
                             'Name': 'plateacquisition_name_8',
                             'StartTime': 1,
-                            'omero:details': {'@type': 'TBD#Details'}
+                            'omero:details': {'@type': 'omero:Details'}
                         },
-                        'omero:details': {'@type': 'TBD#Details'}
+                        'omero:details': {'@type': 'omero:Details'}
                     }],
-                    'omero:details': {'@type': 'TBD#Details'}
+                    'omero:details': {'@type': 'omero:Details'}
                 }],
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }]
         }

--- a/tests/unit/test_image_pixels_encoder.py
+++ b/tests/unit/test_image_pixels_encoder.py
@@ -17,7 +17,7 @@ class TestImagePixelsEncoder(object):
 
     def test_image_encoder(self, image):
         encoder = get_encoder(image.__class__)
-        v = encoder.encode(image)
+        v = encoder.encode(image, True)
         assert v == {
             '@context': {
                 "ome": OME_CONTEXT,
@@ -42,8 +42,12 @@ class TestImagePixelsEncoder(object):
 
     def test_image_pixels_encoder(self, image_pixels):
         encoder = get_encoder(image_pixels.__class__)
-        v = encoder.encode(image_pixels)
+        v = encoder.encode(image_pixels, True)
         assert v == {
+            '@context': {
+                "ome": OME_CONTEXT,
+                "omero": OMERO_CONTEXT,
+            },
             '@id': 1,
             '@type': '%s#Image' % OME_SCHEMA_URL,
             'AcquisitionDate': 1,

--- a/tests/unit/test_image_pixels_encoder.py
+++ b/tests/unit/test_image_pixels_encoder.py
@@ -10,6 +10,7 @@
 #
 
 from omero_marshal import get_encoder, OME_SCHEMA_URL
+from omero_marshal.encode import OME_CONTEXT, OMERO_CONTEXT
 
 
 class TestImagePixelsEncoder(object):
@@ -18,6 +19,10 @@ class TestImagePixelsEncoder(object):
         encoder = get_encoder(image.__class__)
         v = encoder.encode(image)
         assert v == {
+            '@context': {
+                "ome": OME_CONTEXT,
+                "omero": OMERO_CONTEXT,
+            },
             '@id': 1,
             '@type': '%s#Image' % OME_SCHEMA_URL,
             'AcquisitionDate': 1,

--- a/tests/unit/test_image_pixels_encoder.py
+++ b/tests/unit/test_image_pixels_encoder.py
@@ -93,13 +93,13 @@ class TestImagePixelsEncoder(object):
                 'omero:waveStart': 1,
                 'DimensionOrder': {
                     '@id': 1,
-                    '@type': 'TBD#DimensionOrder',
+                    '@type': '%s#DimensionOrder' % OME_SCHEMA_URL,
                     'value': 'XYZCT',
                     'omero:details': {'@type': 'TBD#Details'}
                 },
                 'Type': {
                     '@id': 1,
-                    '@type': 'TBD#PixelsType',
+                    '@type': '%s#PixelType' % OME_SCHEMA_URL,
                     'value': 'bit',
                     'omero:details': {'@type': 'TBD#Details'}
                 },
@@ -108,14 +108,14 @@ class TestImagePixelsEncoder(object):
                     '@type': '%s#Channel' % OME_SCHEMA_URL,
                     'AcquisitionMode': {
                         '@id': 1,
-                        '@type': 'TBD#AcquisitionMode',
+                        '@type': '%s#AcquisitionMode' % OME_SCHEMA_URL,
                         'omero:details': {'@type': 'TBD#Details'},
                         'value': 'WideField'
                     },
                     'Color': -1,
                     'ContrastMethod': {
                         '@id': 8,
-                        '@type': 'TBD#ContrastMethod',
+                        '@type': '%s#ContrastMethod' % OME_SCHEMA_URL,
                         'omero:details': {'@type': 'TBD#Details'},
                         'value': 'Fluorescence'
                     },
@@ -134,7 +134,7 @@ class TestImagePixelsEncoder(object):
                     'Fluor': 'GFP',
                     'Illumination': {
                         '@id': 1,
-                        '@type': 'TBD#Illumination',
+                        '@type': '%s#IlluminationType' % OME_SCHEMA_URL,
                         'omero:details': {'@type': 'TBD#Details'},
                         'value': 'Transmitted'
                     },
@@ -162,14 +162,14 @@ class TestImagePixelsEncoder(object):
                     '@type': '%s#Channel' % OME_SCHEMA_URL,
                     'AcquisitionMode': {
                         '@id': 1,
-                        '@type': 'TBD#AcquisitionMode',
+                        '@type': '%s#AcquisitionMode' % OME_SCHEMA_URL,
                         'omero:details': {'@type': 'TBD#Details'},
                         'value': 'WideField'
                     },
                     'Color': -16711681,
                     'ContrastMethod': {
                         '@id': 8,
-                        '@type': 'TBD#ContrastMethod',
+                        '@type': '%s#ContrastMethod' % OME_SCHEMA_URL,
                         'omero:details': {'@type': 'TBD#Details'},
                         'value': 'Fluorescence'
                     },
@@ -188,7 +188,7 @@ class TestImagePixelsEncoder(object):
                     'Fluor': 'DAPI',
                     'Illumination': {
                         '@id': 1,
-                        '@type': 'TBD#Illumination',
+                        '@type': '%s#IlluminationType' % OME_SCHEMA_URL,
                         'omero:details': {'@type': 'TBD#Details'},
                         'value': 'Transmitted'
                     },

--- a/tests/unit/test_image_pixels_encoder.py
+++ b/tests/unit/test_image_pixels_encoder.py
@@ -10,19 +10,14 @@
 #
 
 from omero_marshal import get_encoder, OME_SCHEMA_URL
-from omero_marshal.encode import OME_CONTEXT, OMERO_CONTEXT
-
 
 class TestImagePixelsEncoder(object):
 
-    def test_image_encoder(self, image):
+    def test_image_encoder(self, image, contexts):
         encoder = get_encoder(image.__class__)
         v = encoder.encode(image, True)
         assert v == {
-            '@context': {
-                "ome": OME_CONTEXT,
-                "omero": OMERO_CONTEXT,
-            },
+            **contexts,
             '@id': 1,
             '@type': '%s#Image' % OME_SCHEMA_URL,
             'AcquisitionDate': 1,
@@ -40,14 +35,11 @@ class TestImagePixelsEncoder(object):
             'omero:details': {'@type': 'TBD#Details'}
         }
 
-    def test_image_pixels_encoder(self, image_pixels):
+    def test_image_pixels_encoder(self, image_pixels, contexts):
         encoder = get_encoder(image_pixels.__class__)
         v = encoder.encode(image_pixels, True)
         assert v == {
-            '@context': {
-                "ome": OME_CONTEXT,
-                "omero": OMERO_CONTEXT,
-            },
+            **contexts,
             '@id': 1,
             '@type': '%s#Image' % OME_SCHEMA_URL,
             'AcquisitionDate': 1,

--- a/tests/unit/test_image_pixels_encoder.py
+++ b/tests/unit/test_image_pixels_encoder.py
@@ -28,11 +28,11 @@ class TestImagePixelsEncoder(object):
             'omero:series': 0,
             'omero:format': {
                 '@id': 1,
-                '@type': 'TBD#Format',
+                '@type': 'omero:Format',
                 'value': 'PNG',
-                'omero:details': {'@type': 'TBD#Details'},
+                'omero:details': {'@type': 'omero:Details'},
             },
-            'omero:details': {'@type': 'TBD#Details'}
+            'omero:details': {'@type': 'omero:Details'}
         }
 
     def test_image_pixels_encoder(self, image_pixels, contexts):
@@ -50,28 +50,28 @@ class TestImagePixelsEncoder(object):
             'omero:series': 0,
             'omero:format': {
                 '@id': 1,
-                '@type': 'TBD#Format',
+                '@type': 'omero:Format',
                 'value': 'PNG',
-                'omero:details': {'@type': 'TBD#Details'},
+                'omero:details': {'@type': 'omero:Details'},
             },
             'Pixels': {
                 '@id': 1,
                 '@type': '%s#Pixels' % OME_SCHEMA_URL,
                 'omero:methodology': 'methodology',
                 'PhysicalSizeX': {
-                    '@type': 'TBD#LengthI',
+                    '@type': 'omero:LengthI',
                     'Unit': 'MICROMETER',
                     'Symbol': 'µm',
                     'Value': 1.0
                 },
                 'PhysicalSizeY': {
-                    '@type': 'TBD#LengthI',
+                    '@type': 'omero:LengthI',
                     'Unit': 'MICROMETER',
                     'Symbol': 'µm',
                     'Value': 2.0
                 },
                 'PhysicalSizeZ': {
-                    '@type': 'TBD#LengthI',
+                    '@type': 'omero:LengthI',
                     'Unit': 'MICROMETER',
                     'Symbol': 'µm',
                     'Value': 3.0
@@ -84,7 +84,7 @@ class TestImagePixelsEncoder(object):
                 'SizeC': 4,
                 'SizeT': 5,
                 'TimeIncrement': {
-                    '@type': 'TBD#TimeI',
+                    '@type': 'omero:TimeI',
                     'Unit': 'MILLISECOND',
                     'Symbol': 'ms',
                     'Value': 1.0
@@ -95,13 +95,13 @@ class TestImagePixelsEncoder(object):
                     '@id': 1,
                     '@type': '%s#DimensionOrder' % OME_SCHEMA_URL,
                     'value': 'XYZCT',
-                    'omero:details': {'@type': 'TBD#Details'}
+                    'omero:details': {'@type': 'omero:Details'}
                 },
                 'Type': {
                     '@id': 1,
                     '@type': '%s#PixelType' % OME_SCHEMA_URL,
                     'value': 'bit',
-                    'omero:details': {'@type': 'TBD#Details'}
+                    'omero:details': {'@type': 'omero:Details'}
                 },
                 'Channels': [{
                     '@id': 1,
@@ -109,24 +109,24 @@ class TestImagePixelsEncoder(object):
                     'AcquisitionMode': {
                         '@id': 1,
                         '@type': '%s#AcquisitionMode' % OME_SCHEMA_URL,
-                        'omero:details': {'@type': 'TBD#Details'},
+                        'omero:details': {'@type': 'omero:Details'},
                         'value': 'WideField'
                     },
                     'Color': -1,
                     'ContrastMethod': {
                         '@id': 8,
                         '@type': '%s#ContrastMethod' % OME_SCHEMA_URL,
-                        'omero:details': {'@type': 'TBD#Details'},
+                        'omero:details': {'@type': 'omero:Details'},
                         'value': 'Fluorescence'
                     },
                     'EmissionWavelength': {
-                        '@type': 'TBD#LengthI',
+                        '@type': 'omero:LengthI',
                         'Symbol': 'nm',
                         'Unit': 'NANOMETER',
                         'Value': 509.0
                     },
                     'ExcitationWavelength': {
-                        '@type': 'TBD#LengthI',
+                        '@type': 'omero:LengthI',
                         'Symbol': 'nm',
                         'Unit': 'NANOMETER',
                         'Value': 488.0
@@ -135,13 +135,13 @@ class TestImagePixelsEncoder(object):
                     'Illumination': {
                         '@id': 1,
                         '@type': '%s#IlluminationType' % OME_SCHEMA_URL,
-                        'omero:details': {'@type': 'TBD#Details'},
+                        'omero:details': {'@type': 'omero:Details'},
                         'value': 'Transmitted'
                     },
                     'NDFilter': 1.0,
                     'Name': 'GFP/488',
                     'PinholeSize': {
-                        '@type': 'TBD#LengthI',
+                        '@type': 'omero:LengthI',
                         'Symbol': 'nm',
                         'Unit': 'NANOMETER',
                         'Value': 1.0
@@ -149,12 +149,12 @@ class TestImagePixelsEncoder(object):
                     'PockelCellSetting': 0,
                     'SamplesPerPixel': 2,
                     'omero:LogicalChannelId': 1,
-                    'omero:details': {'@type': 'TBD#Details'},
+                    'omero:details': {'@type': 'omero:Details'},
                     'omero:lookupTable': 'rainbow',
                     'omero:photometricInterpretation': {
                         '@id': 1,
-                        '@type': 'TBD#PhotometricInterpretation',
-                        'omero:details': {'@type': 'TBD#Details'},
+                        '@type': 'omero:PhotometricInterpretation',
+                        'omero:details': {'@type': 'omero:Details'},
                         'value': 'RGB'
                     }
                 }, {
@@ -163,24 +163,24 @@ class TestImagePixelsEncoder(object):
                     'AcquisitionMode': {
                         '@id': 1,
                         '@type': '%s#AcquisitionMode' % OME_SCHEMA_URL,
-                        'omero:details': {'@type': 'TBD#Details'},
+                        'omero:details': {'@type': 'omero:Details'},
                         'value': 'WideField'
                     },
                     'Color': -16711681,
                     'ContrastMethod': {
                         '@id': 8,
                         '@type': '%s#ContrastMethod' % OME_SCHEMA_URL,
-                        'omero:details': {'@type': 'TBD#Details'},
+                        'omero:details': {'@type': 'omero:Details'},
                         'value': 'Fluorescence'
                     },
                     'EmissionWavelength': {
-                        '@type': 'TBD#LengthI',
+                        '@type': 'omero:LengthI',
                         'Symbol': 'nm',
                         'Unit': 'NANOMETER',
                         'Value': 470.0
                     },
                     'ExcitationWavelength': {
-                        '@type': 'TBD#LengthI',
+                        '@type': 'omero:LengthI',
                         'Symbol': 'nm',
                         'Unit': 'NANOMETER',
                         'Value': 405.0
@@ -189,13 +189,13 @@ class TestImagePixelsEncoder(object):
                     'Illumination': {
                         '@id': 1,
                         '@type': '%s#IlluminationType' % OME_SCHEMA_URL,
-                        'omero:details': {'@type': 'TBD#Details'},
+                        'omero:details': {'@type': 'omero:Details'},
                         'value': 'Transmitted'
                     },
                     'NDFilter': 1.0,
                     'Name': 'DAPI/405',
                     'PinholeSize': {
-                        '@type': 'TBD#LengthI',
+                        '@type': 'omero:LengthI',
                         'Symbol': 'nm',
                         'Unit': 'NANOMETER',
                         'Value': 2.0
@@ -203,16 +203,16 @@ class TestImagePixelsEncoder(object):
                     'PockelCellSetting': 0,
                     'SamplesPerPixel': 2,
                     'omero:LogicalChannelId': 2,
-                    'omero:details': {'@type': 'TBD#Details'},
+                    'omero:details': {'@type': 'omero:Details'},
                     'omero:lookupTable': 'rainbow',
                     'omero:photometricInterpretation': {
                         '@id': 1,
-                        '@type': 'TBD#PhotometricInterpretation',
-                        'omero:details': {'@type': 'TBD#Details'},
+                        '@type': 'omero:PhotometricInterpretation',
+                        'omero:details': {'@type': 'omero:Details'},
                         'value': 'RGB'
                     }
                 }],
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             },
-            'omero:details': {'@type': 'TBD#Details'}
+            'omero:details': {'@type': 'omero:Details'}
         }

--- a/tests/unit/test_image_pixels_encoder.py
+++ b/tests/unit/test_image_pixels_encoder.py
@@ -9,7 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder, OME_SCHEMA_URL
+from omero_marshal import get_encoder
 
 class TestImagePixelsEncoder(object):
 
@@ -19,7 +19,7 @@ class TestImagePixelsEncoder(object):
         assert v == {
             **contexts,
             '@id': 1,
-            '@type': '%s#Image' % OME_SCHEMA_URL,
+            '@type': 'Image',
             'AcquisitionDate': 1,
             'Name': 'image_name_1',
             'omero:archived': False,
@@ -41,7 +41,7 @@ class TestImagePixelsEncoder(object):
         assert v == {
             **contexts,
             '@id': 1,
-            '@type': '%s#Image' % OME_SCHEMA_URL,
+            '@type': 'Image',
             'AcquisitionDate': 1,
             'Name': 'image_name_1',
             'omero:archived': False,
@@ -56,7 +56,7 @@ class TestImagePixelsEncoder(object):
             },
             'Pixels': {
                 '@id': 1,
-                '@type': '%s#Pixels' % OME_SCHEMA_URL,
+                '@type': 'Pixels',
                 'omero:methodology': 'methodology',
                 'PhysicalSizeX': {
                     '@type': 'omero:LengthI',
@@ -93,29 +93,29 @@ class TestImagePixelsEncoder(object):
                 'omero:waveStart': 1,
                 'DimensionOrder': {
                     '@id': 1,
-                    '@type': '%s#DimensionOrder' % OME_SCHEMA_URL,
+                    '@type': 'DimensionOrder',
                     'value': 'XYZCT',
                     'omero:details': {'@type': 'omero:Details'}
                 },
                 'Type': {
                     '@id': 1,
-                    '@type': '%s#PixelType' % OME_SCHEMA_URL,
+                    '@type': 'PixelType',
                     'value': 'bit',
                     'omero:details': {'@type': 'omero:Details'}
                 },
                 'Channels': [{
                     '@id': 1,
-                    '@type': '%s#Channel' % OME_SCHEMA_URL,
+                    '@type': 'Channel',
                     'AcquisitionMode': {
                         '@id': 1,
-                        '@type': '%s#AcquisitionMode' % OME_SCHEMA_URL,
+                        '@type': 'AcquisitionMode',
                         'omero:details': {'@type': 'omero:Details'},
                         'value': 'WideField'
                     },
                     'Color': -1,
                     'ContrastMethod': {
                         '@id': 8,
-                        '@type': '%s#ContrastMethod' % OME_SCHEMA_URL,
+                        '@type': 'ContrastMethod',
                         'omero:details': {'@type': 'omero:Details'},
                         'value': 'Fluorescence'
                     },
@@ -134,7 +134,7 @@ class TestImagePixelsEncoder(object):
                     'Fluor': 'GFP',
                     'Illumination': {
                         '@id': 1,
-                        '@type': '%s#IlluminationType' % OME_SCHEMA_URL,
+                        '@type': 'IlluminationType',
                         'omero:details': {'@type': 'omero:Details'},
                         'value': 'Transmitted'
                     },
@@ -159,17 +159,17 @@ class TestImagePixelsEncoder(object):
                     }
                 }, {
                     '@id': 2,
-                    '@type': '%s#Channel' % OME_SCHEMA_URL,
+                    '@type': 'Channel',
                     'AcquisitionMode': {
                         '@id': 1,
-                        '@type': '%s#AcquisitionMode' % OME_SCHEMA_URL,
+                        '@type': 'AcquisitionMode',
                         'omero:details': {'@type': 'omero:Details'},
                         'value': 'WideField'
                     },
                     'Color': -16711681,
                     'ContrastMethod': {
                         '@id': 8,
-                        '@type': '%s#ContrastMethod' % OME_SCHEMA_URL,
+                        '@type': 'ContrastMethod',
                         'omero:details': {'@type': 'omero:Details'},
                         'value': 'Fluorescence'
                     },
@@ -188,7 +188,7 @@ class TestImagePixelsEncoder(object):
                     'Fluor': 'DAPI',
                     'Illumination': {
                         '@id': 1,
-                        '@type': '%s#IlluminationType' % OME_SCHEMA_URL,
+                        '@type': 'IlluminationType',
                         'omero:details': {'@type': 'omero:Details'},
                         'value': 'Transmitted'
                     },

--- a/tests/unit/test_register_decoder.py
+++ b/tests/unit/test_register_decoder.py
@@ -9,11 +9,11 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_decoder, ROI_SCHEMA_URL
+from omero_marshal import get_decoder
 
 
 class TestRegisterDecoder(object):
 
     def test_roi_decoder_registered(self):
-        decoder = get_decoder('%s#ROI' % ROI_SCHEMA_URL)
+        decoder = get_decoder('ROI')
         assert decoder is not None

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -9,8 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder, SCHEMA_VERSION, ROI_SCHEMA_URL
-from omero_marshal import SA_SCHEMA_URL, OME_SCHEMA_URL
+from omero_marshal import get_encoder, SCHEMA_VERSION
 
 
 class TestShapeEncoder(object):
@@ -18,61 +17,61 @@ class TestShapeEncoder(object):
     def annotation_data(self):
         return {
             'Annotations': [{
-                '@type': '%s#BooleanAnnotation' % SA_SCHEMA_URL,
+                '@type': 'BooleanAnnotation',
                 'Description': 'the_description',
                 'Namespace': 'boolean_annotation',
                 'Value': True,
                 'omero:details': {'@type': 'omero:Details'}
             }, {
-                '@type': '%s#CommentAnnotation' % SA_SCHEMA_URL,
+                '@type': 'CommentAnnotation',
                 'Description': 'the_description',
                 'Namespace': 'comment_annotation',
                 'Value': 'text_value',
                 'omero:details': {'@type': 'omero:Details'}
             }, {
-                '@type': '%s#DoubleAnnotation' % SA_SCHEMA_URL,
+                '@type': 'DoubleAnnotation',
                 'Description': 'the_description',
                 'Namespace': 'double_annotation',
                 'Value': 1.0,
                 'omero:details': {'@type': 'omero:Details'}
             }, {
-                '@type': '%s#LongAnnotation' % SA_SCHEMA_URL,
+                '@type': 'LongAnnotation',
                 'Description': 'the_description',
                 'Namespace': 'long_annotation',
                 'Value': 1,
                 'omero:details': {'@type': 'omero:Details'}
             }, {
-                '@type': '%s#MapAnnotation' % SA_SCHEMA_URL,
+                '@type': 'MapAnnotation',
                 'Description': 'the_description',
                 'Namespace': 'map_annotation',
                 'Value': [['a', '1'], ['b', '2']],
                 'omero:details': {'@type': 'omero:Details'}
             }, {
-                '@type': '%s#TagAnnotation' % SA_SCHEMA_URL,
+                '@type': 'TagAnnotation',
                 'Description': 'the_description',
                 'Namespace': 'tag_annotation',
                 'Value': 'tag_value',
                 'omero:details': {'@type': 'omero:Details'}
             }, {
-                '@type': '%s#TermAnnotation' % SA_SCHEMA_URL,
+                '@type': 'TermAnnotation',
                 'Description': 'the_description',
                 'Namespace': 'term_annotation',
                 'Value': 'term_value',
                 'omero:details': {'@type': 'omero:Details'}
             }, {
-                '@type': '%s#TimestampAnnotation' % SA_SCHEMA_URL,
+                '@type': 'TimestampAnnotation',
                 'Description': 'the_description',
                 'Namespace': 'timestamp_annotation',
                 'Value': 1,
                 'omero:details': {'@type': 'omero:Details'}
             }, {
-                '@type': '%s#XmlAnnotation' % SA_SCHEMA_URL,
+                '@type': 'XmlAnnotation',
                 'Description': 'the_description',
                 'Namespace': 'xml_annotation',
                 'Value': '<xml_value></xml_value>',
                 'omero:details': {'@type': 'omero:Details'}
             }, {
-                '@type': '%s#FileAnnotation' % SA_SCHEMA_URL,
+                '@type': 'FileAnnotation',
                 'Description': 'the_description',
                 'File': {
                     '@id': 1,
@@ -105,13 +104,13 @@ class TestShapeEncoder(object):
         assert roi['@id'] == 1
         assert roi['Name'] == 'the_name'
         assert roi['Description'] == 'the_description'
-        assert roi['@type'] == '%s#ROI' % ROI_SCHEMA_URL
+        assert roi['@type'] == 'ROI'
         assert roi['omero:details'] == {
             '@type': 'omero:Details',
             'group': {
                 '@id': 1,
                 '@type':
-                    '%s#ExperimenterGroup' % OME_SCHEMA_URL,
+                    'ExperimenterGroup',
                 'Description': 'the_description',
                 'Name': 'the_name',
                 'omero:details': {'@type': 'omero:Details'}
@@ -119,7 +118,7 @@ class TestShapeEncoder(object):
             'owner': {
                 '@id': 1,
                 '@type':
-                    '%s#Experimenter' % OME_SCHEMA_URL,
+                    'Experimenter',
                 'Email': 'the_email',
                 'FirstName': 'the_firstName',
                 'Institution': 'the_institution',
@@ -196,7 +195,7 @@ class TestShapeEncoder(object):
     def assert_ellipse(self, ellipse, has_annotations=False):
         self.assert_shape(ellipse, has_annotations=has_annotations)
         assert ellipse['@id'] == 1
-        assert ellipse['@type'] == '%s#Ellipse' % ROI_SCHEMA_URL
+        assert ellipse['@type'] == 'Ellipse'
         assert ellipse['X'] == 1.0
         assert ellipse['Y'] == 2.0
         assert ellipse['RadiusX'] == 3.0
@@ -205,14 +204,14 @@ class TestShapeEncoder(object):
     def assert_rectangle(self, rectangle):
         self.assert_shape(rectangle)
         assert rectangle['@id'] == 2
-        assert rectangle['@type'] == '%s#Rectangle' % ROI_SCHEMA_URL
+        assert rectangle['@type'] == 'Rectangle'
         assert rectangle['X'] == 1.0
         assert rectangle['Y'] == 2.0
         assert rectangle['Width'] == 3.0
         assert rectangle['Height'] == 4.0
 
     def assert_transform(self, transform):
-        assert transform['@type'] == '%s#AffineTransform' % ROI_SCHEMA_URL
+        assert transform['@type'] == 'AffineTransform'
         assert transform['A00'] == 1.0
         assert transform['A10'] == 0.0
         assert transform['A01'] == 0.0
@@ -251,7 +250,7 @@ class TestPointEncoder(TestShapeEncoder):
         v = encoder.encode(point)
         self.assert_shape(v)
         assert v['@id'] == 3
-        assert v['@type'] == '%s#Point' % ROI_SCHEMA_URL
+        assert v['@type'] == 'Point'
         assert v['X'] == 1.0
         assert v['Y'] == 2.0
 
@@ -263,7 +262,7 @@ class TestLabelEncoder(TestShapeEncoder):
         v = encoder.encode(label)
         self.assert_shape(v)
         assert v['@id'] == 7
-        assert v['@type'] == '%s#Label' % ROI_SCHEMA_URL
+        assert v['@type'] == 'Label'
         assert v['X'] == 1.0
         assert v['Y'] == 2.0
 
@@ -275,7 +274,7 @@ class TestPolylineEncoder(TestShapeEncoder):
         v = encoder.encode(polyline)
         self.assert_shape(v)
         assert v['@id'] == 4
-        assert v['@type'] == '%s#Polyline' % ROI_SCHEMA_URL
+        assert v['@type'] == 'Polyline'
         assert v['Points'] == '0,0 1,2 3,5'
         if SCHEMA_VERSION != '2015-01':
             assert v['MarkerStart'] == 'Arrow'
@@ -289,7 +288,7 @@ class TestPolygonEncoder(TestShapeEncoder):
         v = encoder.encode(polygon)
         self.assert_shape(v)
         assert v['@id'] == 5
-        assert v['@type'] == '%s#Polygon' % ROI_SCHEMA_URL
+        assert v['@type'] == 'Polygon'
         assert v['Points'] == '0,0 1,2 3,5'
 
 
@@ -300,7 +299,7 @@ class TestLineEncoder(TestShapeEncoder):
         v = encoder.encode(line)
         self.assert_shape(v)
         assert v['@id'] == 6
-        assert v['@type'] == '%s#Line' % ROI_SCHEMA_URL
+        assert v['@type'] == 'Line'
         assert v['X1'] == 0.0
         assert v['Y1'] == 0.0
         assert v['X2'] == 1.0
@@ -338,7 +337,7 @@ class TestMaskEncoder(TestShapeEncoder):
         v = encoder.encode(mask)
         self.assert_shape(v)
         assert v['@id'] == 8
-        assert v['@type'] == '%s#Mask' % ROI_SCHEMA_URL
+        assert v['@type'] == 'Mask'
         assert v['X'] == 0.0
         assert v['Y'] == 0.0
         assert v['Width'] == 1.0

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -22,79 +22,79 @@ class TestShapeEncoder(object):
                 'Description': 'the_description',
                 'Namespace': 'boolean_annotation',
                 'Value': True,
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@type': '%s#CommentAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'comment_annotation',
                 'Value': 'text_value',
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@type': '%s#DoubleAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'double_annotation',
                 'Value': 1.0,
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@type': '%s#LongAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'long_annotation',
                 'Value': 1,
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@type': '%s#MapAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'map_annotation',
                 'Value': [['a', '1'], ['b', '2']],
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@type': '%s#TagAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'tag_annotation',
                 'Value': 'tag_value',
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@type': '%s#TermAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'term_annotation',
                 'Value': 'term_value',
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@type': '%s#TimestampAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'timestamp_annotation',
                 'Value': 1,
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@type': '%s#XmlAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'xml_annotation',
                 'Value': '<xml_value></xml_value>',
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }, {
                 '@type': '%s#FileAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'File': {
                     '@id': 1,
-                    '@type': 'TBD#OriginalFile',
+                    '@type': 'omero:OriginalFile',
                     'atime': 3,
                     'ctime': 5,
                     'hash': '1a0b045d',
                     'hasher': {
                         '@id': 1,
-                        '@type': 'TBD#ChecksumAlgorithm',
-                        'omero:details': {'@type': 'TBD#Details'},
+                        '@type': 'omero:ChecksumAlgorithm',
+                        'omero:details': {'@type': 'omero:Details'},
                         'value': 'Adler-32'
                     },
                     'mtime': 4,
-                    'omero:details': {'@type': 'TBD#Details'},
+                    'omero:details': {'@type': 'omero:Details'},
                     'path': 'path',
                     'size': 2,
                     'mimetype': 'application/octet-stream',
                     'name': 'name'
                 },
                 'Namespace': 'file_annotation',
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             }]
         }
 
@@ -107,14 +107,14 @@ class TestShapeEncoder(object):
         assert roi['Description'] == 'the_description'
         assert roi['@type'] == '%s#ROI' % ROI_SCHEMA_URL
         assert roi['omero:details'] == {
-            '@type': 'TBD#Details',
+            '@type': 'omero:Details',
             'group': {
                 '@id': 1,
                 '@type':
                     '%s#ExperimenterGroup' % OME_SCHEMA_URL,
                 'Description': 'the_description',
                 'Name': 'the_name',
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             },
             'owner': {
                 '@id': 1,
@@ -126,10 +126,10 @@ class TestShapeEncoder(object):
                 'LastName': 'the_lastName',
                 'MiddleName': 'the_middleName',
                 'UserName': 'the_omeName',
-                'omero:details': {'@type': 'TBD#Details'}
+                'omero:details': {'@type': 'omero:Details'}
             },
             'permissions': {
-                '@type': 'TBD#Permissions',
+                '@type': 'omero:Permissions',
                 'canAnnotate': True,
                 'canDelete': True,
                 'canEdit': True,
@@ -144,13 +144,13 @@ class TestShapeEncoder(object):
                 'isWorldWrite': True
             },
             'externalInfo': {
-                '@type': 'TBD#ExternalInfo',
+                '@type': 'omero:ExternalInfo',
                 'EntityId': 123,
                 'EntityType': 'test',
                 'Lsid': 'ABCDEF',
                 'Uuid': 'f90a1fd5-275c-4d14-82b3-87b5ef0f07de',
                 'omero:details': {
-                    '@type': 'TBD#Details'
+                    '@type': 'omero:Details'
                 },
             },
         }
@@ -165,7 +165,7 @@ class TestShapeEncoder(object):
         assert shape['StrokeColor'] == 0xffff0000
         assert shape['StrokeDashArray'] == 'inherit'
         assert shape['StrokeWidth'] == {
-            '@type': 'TBD#LengthI',
+            '@type': 'omero:LengthI',
             'Unit': 'PIXEL',
             'Symbol': 'pixel',
             'Value': 4
@@ -173,7 +173,7 @@ class TestShapeEncoder(object):
         assert shape['Text'] == 'the_text'
         assert shape['FontFamily'] == 'cursive'
         assert shape['FontSize'] == {
-            '@type': 'TBD#LengthI',
+            '@type': 'omero:LengthI',
             'Unit': 'POINT',
             'Symbol': 'pt',
             'Value': 12
@@ -187,7 +187,7 @@ class TestShapeEncoder(object):
         assert shape['TheT'] == 2
         assert shape['TheC'] == 1
         self.assert_transform(shape['Transform'])
-        assert shape['omero:details'] == {'@type': 'TBD#Details'}
+        assert shape['omero:details'] == {'@type': 'omero:Details'}
         if not has_annotations:
             assert shape.get('annotations') is None
         else:
@@ -220,7 +220,7 @@ class TestShapeEncoder(object):
         assert transform['A02'] == 0.0
         assert transform['A12'] == 0.0
         if SCHEMA_VERSION != '2015-01':
-            assert transform['omero:details'] == {'@type': 'TBD#Details'}
+            assert transform['omero:details'] == {'@type': 'omero:Details'}
 
 
 class TestEllipseEncoder(TestShapeEncoder):


### PR DESCRIPTION
This is an attempt to update the omero-marshal JSON output to replace all uses of `TBD`. This is done by introducing a top-level context of:

```
{'@context': {'@base': 'http://www.openmicroscopy.org/Schemas/OME/2016-06#',
              'omero': 'http://www.openmicroscopy.org/Schemas/OMERO/2016-06#'},
```

Decisions made that may need reviewing:

 - Adds an argument to `encode()` "include_context"
   - Sets include_context true for the top-level but internal calls revert to False
   - Sets include_context to False for tiny elements like permissions, details, and externalInfo
 - Essentially ignores the 2015 split schema URLs since they seem to be untested (remove?)
 - Moves all enums into the default (@base) OME schema namespace
 - Renames PixelsType to the @base PixelType
 - Renames Illumination to the @base IlluminationType
 - Moves all other TBD classes into the as-yet nonextant omero: namespace https://www.openmicroscopy.org/Schemas/OMERO/2016-06/
   - decided again shortening the omero: prefix to save characters (e.g. `ro:`)